### PR TITLE
Add admin dashboard with authentication

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,66 @@
+interface Env {
+  JWT_SECRET: string;
+}
+
+async function verifyJWT(token: string, secret: string): Promise<boolean> {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return false;
+
+    const [header, payload, sig] = parts;
+    const data = `${header}.${payload}`;
+
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["verify"]
+    );
+
+    const sigBytes = Uint8Array.from(
+      atob(sig.replace(/-/g, "+").replace(/_/g, "/")),
+      (c) => c.charCodeAt(0)
+    );
+    const valid = await crypto.subtle.verify(
+      "HMAC",
+      key,
+      sigBytes,
+      new TextEncoder().encode(data)
+    );
+
+    if (!valid) return false;
+
+    const decoded = JSON.parse(
+      atob(payload.replace(/-/g, "+").replace(/_/g, "/"))
+    );
+    if (decoded.exp && decoded.exp < Math.floor(Date.now() / 1000))
+      return false;
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const { request, next, env } = context;
+  const url = new URL(request.url);
+
+  // Only protect /admin routes
+  if (!url.pathname.startsWith("/admin")) {
+    return next();
+  }
+
+  const cookie = request.headers.get("Cookie") ?? "";
+  const tokenMatch = cookie.match(/auth_token=([^;]+)/);
+  const token = tokenMatch?.[1];
+
+  if (!token || !(await verifyJWT(token, env.JWT_SECRET))) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirect", url.pathname);
+    return Response.redirect(loginUrl.toString(), 302);
+  }
+
+  return next();
+};

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -43,7 +43,11 @@ async function verifyJWT(token: string, secret: string): Promise<boolean> {
   }
 }
 
-export const onRequest: PagesFunction<Env> = async (context) => {
+export async function onRequest(context: {
+  request: Request;
+  next(): Promise<Response>;
+  env: Env;
+}): Promise<Response> {
   const { request, next, env } = context;
   const url = new URL(request.url);
 
@@ -63,4 +67,4 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   }
 
   return next();
-};
+}

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -18,10 +18,15 @@ async function verifyJWT(token: string, secret: string): Promise<boolean> {
       ["verify"]
     );
 
-    const sigBytes = Uint8Array.from(
-      atob(sig.replace(/-/g, "+").replace(/_/g, "/")),
-      (c) => c.charCodeAt(0)
-    );
+    const b64decode = (s: string) =>
+      atob(
+        (s.replace(/-/g, "+").replace(/_/g, "/") + "====").slice(
+          0,
+          s.length + ((4 - (s.length % 4)) % 4)
+        )
+      );
+
+    const sigBytes = Uint8Array.from(b64decode(sig), (c) => c.charCodeAt(0));
     const valid = await crypto.subtle.verify(
       "HMAC",
       key,
@@ -31,9 +36,7 @@ async function verifyJWT(token: string, secret: string): Promise<boolean> {
 
     if (!valid) return false;
 
-    const decoded = JSON.parse(
-      atob(payload.replace(/-/g, "+").replace(/_/g, "/"))
-    );
+    const decoded = JSON.parse(b64decode(payload));
     if (decoded.exp && decoded.exp < Math.floor(Date.now() / 1000))
       return false;
 

--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -1,0 +1,68 @@
+interface Env {
+  ADMIN_PASSWORD: string;
+  JWT_SECRET: string;
+}
+
+async function signJWT(payload: object, secret: string): Promise<string> {
+  const encode = (obj: object) =>
+    btoa(JSON.stringify(obj))
+      .replace(/=/g, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+
+  const header = encode({ alg: "HS256", typ: "JWT" });
+  const body = encode(payload);
+  const data = `${header}.${body}`;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(data)
+  );
+
+  const sigB64 = btoa(String.fromCharCode(...new Uint8Array(signature)))
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+
+  return `${data}.${sigB64}`;
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  let password: string | undefined;
+
+  const contentType = request.headers.get("Content-Type") ?? "";
+  if (contentType.includes("application/json")) {
+    const body = (await request.json()) as { password?: string };
+    password = body.password;
+  } else {
+    const form = await request.formData();
+    password = form.get("password")?.toString();
+  }
+
+  if (!password || !env.ADMIN_PASSWORD || password !== env.ADMIN_PASSWORD) {
+    return new Response(JSON.stringify({ error: "Invalid credentials" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const exp = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // 24 hours
+  const token = await signJWT({ sub: "admin", exp }, env.JWT_SECRET);
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Set-Cookie": `auth_token=${token}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=86400`,
+    },
+  });
+};

--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -36,7 +36,11 @@ async function signJWT(payload: object, secret: string): Promise<string> {
   return `${data}.${sigB64}`;
 }
 
-export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+export async function onRequestPost(context: {
+  request: Request;
+  env: Env;
+}): Promise<Response> {
+  const { request, env } = context;
   let password: string | undefined;
 
   const contentType = request.headers.get("Content-Type") ?? "";
@@ -65,4 +69,4 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
       "Set-Cookie": `auth_token=${token}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=86400`,
     },
   });
-};
+}

--- a/functions/api/logout.ts
+++ b/functions/api/logout.ts
@@ -1,4 +1,7 @@
-export const onRequestPost: PagesFunction = async () => {
+export async function onRequestPost(_context: {
+  request: Request;
+  env: Record<string, unknown>;
+}): Promise<Response> {
   return new Response(JSON.stringify({ success: true }), {
     status: 200,
     headers: {
@@ -7,4 +10,4 @@ export const onRequestPost: PagesFunction = async () => {
         "auth_token=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0",
     },
   });
-};
+}

--- a/functions/api/logout.ts
+++ b/functions/api/logout.ts
@@ -1,0 +1,10 @@
+export const onRequestPost: PagesFunction = async () => {
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Set-Cookie":
+        "auth_token=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0",
+    },
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@fontsource/dm-mono": "^5.2.7",
         "@fontsource/dm-sans": "^5.2.8",
         "@fontsource/playfair-display": "^5.2.8",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "tailwindcss": "^4.2.2"
       },
       "engines": {
@@ -2091,8 +2093,8 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2101,8 +2103,8 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2660,8 +2662,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@fontsource/dm-mono": "^5.2.7",
     "@fontsource/dm-sans": "^5.2.8",
     "@fontsource/playfair-display": "^5.2.8",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "tailwindcss": "^4.2.2"
   }
 }

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type FormEvent } from 'react';
 
 type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
 
@@ -28,7 +28,7 @@ export default function ContactForm() {
     setForm((current) => ({ ...current, [key]: value }));
   }
 
-  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     if (submitState === 'submitting') {

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,0 +1,255 @@
+---
+import BaseHead from '../../components/BaseHead.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { SITE_TITLE } from '../../consts';
+import { getCollection } from 'astro:content';
+
+const posts = await getCollection('blog');
+const sorted = posts.sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+);
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title={`Admin | ${SITE_TITLE}`}
+      description="Admin dashboard"
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section class="admin-shell">
+        <div class="admin-header">
+          <div>
+            <p class="eyebrow">Admin</p>
+            <h1>Dashboard</h1>
+          </div>
+          <button id="logout-btn" class="logout-btn">Sign out</button>
+        </div>
+
+        <div class="admin-content">
+          <div class="stat-grid">
+            <div class="stat-card">
+              <span class="stat-value">{posts.length}</span>
+              <span class="stat-label">Total posts</span>
+            </div>
+          </div>
+
+          <div class="posts-section">
+            <h2>Posts</h2>
+            <ul class="posts-list">
+              {sorted.map((post) => (
+                <li class="post-row">
+                  <a href={`/blog/${post.id}`} class="post-title">
+                    {post.data.title}
+                  </a>
+                  <span class="post-date">
+                    {post.data.pubDate.toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+    </main>
+    <Footer />
+  </body>
+</html>
+
+<script>
+  const logoutBtn = document.getElementById('logout-btn') as HTMLButtonElement;
+
+  logoutBtn.addEventListener('click', async () => {
+    logoutBtn.disabled = true;
+    logoutBtn.textContent = 'Signing out…';
+    await fetch('/api/logout', { method: 'POST' });
+    window.location.href = '/';
+  });
+</script>
+
+<style>
+  main {
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  .admin-shell {
+    min-height: calc(100vh - 68px);
+    padding: 3rem 1.25rem 5rem;
+    background:
+      radial-gradient(circle at top left, rgba(var(--accent-rgb), 0.08), transparent 24%),
+      linear-gradient(165deg, rgba(9, 12, 20, 0.98), rgba(12, 28, 34, 0.96));
+  }
+
+  .admin-header {
+    width: min(860px, 100%);
+    margin: 0 auto 2rem;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .admin-content {
+    width: min(860px, 100%);
+    margin: 0 auto;
+    display: grid;
+    gap: 2rem;
+  }
+
+  .eyebrow {
+    margin: 0 0 0.5rem;
+    color: #f79a6d;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: clamp(2rem, 5vw, 3.5rem);
+    line-height: 1;
+    color: #f5f1e8;
+  }
+
+  .logout-btn {
+    border: 1px solid rgba(135, 148, 171, 0.3);
+    border-radius: 999px;
+    padding: 0.6rem 1.25rem;
+    font: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: rgba(245, 241, 232, 0.8);
+    background: rgba(99, 110, 116, 0.3);
+    cursor: pointer;
+    transition: border-color var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
+    white-space: nowrap;
+  }
+
+  .logout-btn:hover {
+    border-color: rgba(247, 154, 109, 0.5);
+    color: #f79a6d;
+    background: rgba(247, 154, 109, 0.08);
+  }
+
+  .logout-btn:disabled {
+    opacity: 0.5;
+    cursor: wait;
+  }
+
+  .stat-grid {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .stat-card {
+    padding: 1.5rem 2rem;
+    border-radius: 20px;
+    border: 1px solid rgba(135, 148, 171, 0.18);
+    background: rgba(99, 110, 116, 0.4);
+    backdrop-filter: blur(12px);
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 10rem;
+  }
+
+  .stat-value {
+    font-size: 2.5rem;
+    font-weight: 800;
+    color: #f5f1e8;
+    line-height: 1;
+  }
+
+  .stat-label {
+    font-size: 0.9rem;
+    color: rgba(245, 241, 232, 0.6);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+  }
+
+  .posts-section {
+    padding: 1.75rem 2rem;
+    border-radius: 24px;
+    border: 1px solid rgba(135, 148, 171, 0.18);
+    background: rgba(99, 110, 116, 0.4);
+    backdrop-filter: blur(12px);
+  }
+
+  h2 {
+    margin: 0 0 1.25rem;
+    color: #f5f1e8;
+    font-size: 1.25rem;
+    font-weight: 700;
+  }
+
+  .posts-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .post-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    transition: background var(--transition-fast);
+  }
+
+  .post-row:hover {
+    background: rgba(135, 148, 171, 0.12);
+  }
+
+  .post-title {
+    color: #f5f1e8;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 1rem;
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .post-title:hover {
+    color: #f79a6d;
+  }
+
+  .post-date {
+    font-size: 0.85rem;
+    color: rgba(245, 241, 232, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 720px) {
+    .admin-shell {
+      padding: 2rem 1rem 4rem;
+    }
+
+    .posts-section {
+      padding: 1.25rem 1rem;
+    }
+  }
+</style>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -1,0 +1,250 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { SITE_TITLE } from '../consts';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title={`Sign In | ${SITE_TITLE}`}
+      description="Sign in to access the admin area."
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section class="login-shell">
+        <div class="login-intro">
+          <p class="eyebrow">Admin</p>
+          <h1>Sign in</h1>
+          <p class="lede">Access restricted to authorized users.</p>
+        </div>
+        <div class="login-card">
+          <form id="login-form" class="login-form" novalidate>
+            <div class="field-group">
+              <label for="password">Password</label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                autocomplete="current-password"
+                required
+                placeholder="Enter your password"
+              />
+            </div>
+            <div class="form-footer">
+              <button type="submit" id="submit-btn">Sign in</button>
+            </div>
+            <p id="form-status" class="form-status" aria-live="polite" hidden></p>
+          </form>
+        </div>
+      </section>
+    </main>
+    <Footer />
+  </body>
+</html>
+
+<script>
+  const form = document.getElementById('login-form') as HTMLFormElement;
+  const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement;
+  const statusEl = document.getElementById('form-status') as HTMLParagraphElement;
+
+  function showStatus(msg: string, type: 'success' | 'error') {
+    statusEl.textContent = msg;
+    statusEl.className = `form-status ${type}`;
+    statusEl.hidden = false;
+  }
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Signing in…';
+    statusEl.hidden = true;
+
+    const password = (document.getElementById('password') as HTMLInputElement).value;
+
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+
+      if (res.ok) {
+        const params = new URLSearchParams(window.location.search);
+        const redirect = params.get('redirect') ?? '/admin';
+        window.location.href = redirect;
+      } else {
+        showStatus('Invalid password. Please try again.', 'error');
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Sign in';
+      }
+    } catch {
+      showStatus('Network error. Please try again.', 'error');
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Sign in';
+    }
+  });
+</script>
+
+<style>
+  main {
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  .login-shell {
+    min-height: calc(100vh - 68px);
+    padding: 4rem 1.25rem 5rem;
+    background:
+      radial-gradient(circle at top left, rgba(var(--accent-rgb), 0.12), transparent 24%),
+      radial-gradient(circle at bottom right, rgba(244, 114, 182, 0.12), transparent 28%),
+      linear-gradient(165deg, rgba(9, 12, 20, 0.98), rgba(12, 28, 34, 0.96));
+  }
+
+  .login-intro,
+  .login-card {
+    width: min(480px, 100%);
+    margin: 0 auto;
+  }
+
+  .login-card {
+    margin-top: 1.75rem;
+    padding: 2.25rem;
+    border-radius: 32px;
+    border: 1px solid rgba(135, 148, 171, 0.18);
+    background: rgba(99, 110, 116, 0.68);
+    backdrop-filter: blur(18px);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+  }
+
+  .eyebrow {
+    margin: 0 0 1rem;
+    color: #f79a6d;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+
+  h1 {
+    margin: 0 0 1rem;
+    font-size: clamp(2.5rem, 6vw, 4rem);
+    line-height: 0.95;
+    color: #f5f1e8;
+  }
+
+  .lede {
+    max-width: 42rem;
+    margin: 0;
+    font-size: clamp(1rem, 2vw, 1.25rem);
+    line-height: 1.65;
+    color: rgba(245, 241, 232, 0.88);
+  }
+
+  .login-form {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .field-group {
+    display: grid;
+    gap: 0.7rem;
+  }
+
+  .field-group label {
+    color: #f5f1e8;
+    font-size: 1.15rem;
+    font-weight: 700;
+  }
+
+  .field-group input {
+    width: 100%;
+    border: 2px solid rgba(35, 62, 69, 0.9);
+    border-radius: 24px;
+    background: rgba(159, 167, 172, 0.76);
+    color: #112027;
+    font: inherit;
+    padding: 1rem 1.15rem;
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
+    box-sizing: border-box;
+  }
+
+  .field-group input:focus {
+    outline: none;
+    border-color: rgba(247, 154, 109, 0.92);
+    box-shadow: 0 0 0 4px rgba(247, 154, 109, 0.16);
+    background: rgba(182, 188, 192, 0.9);
+  }
+
+  .form-footer {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  .login-form button {
+    border: 0;
+    border-radius: 999px;
+    padding: 0.95rem 1.5rem;
+    font: inherit;
+    font-weight: 700;
+    color: #fdfaf5;
+    background: linear-gradient(135deg, #f79a6d, #dd6b8f);
+    cursor: pointer;
+    box-shadow: 0 12px 30px rgba(221, 107, 143, 0.24);
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast), opacity var(--transition-fast);
+  }
+
+  .login-form button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 36px rgba(221, 107, 143, 0.3);
+  }
+
+  .login-form button:disabled {
+    opacity: 0.72;
+    cursor: wait;
+    transform: none;
+  }
+
+  .form-status {
+    margin: 0;
+    padding: 0.95rem 1.1rem;
+    border-radius: 18px;
+    font-weight: 600;
+  }
+
+  .form-status.success {
+    background: rgba(59, 130, 246, 0.14);
+    color: #d8ebff;
+    border: 1px solid rgba(96, 165, 250, 0.32);
+  }
+
+  .form-status.error {
+    background: rgba(239, 68, 68, 0.14);
+    color: #ffe2e2;
+    border: 1px solid rgba(248, 113, 113, 0.3);
+  }
+
+  @media (max-width: 720px) {
+    .login-shell {
+      padding: 2.5rem 1rem 4rem;
+    }
+
+    .login-card {
+      padding: 1.5rem;
+      border-radius: 24px;
+    }
+
+    .login-form button {
+      width: 100%;
+      text-align: center;
+    }
+  }
+</style>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -75,7 +75,10 @@ import { SITE_TITLE } from '../consts';
 
       if (res.ok) {
         const params = new URLSearchParams(window.location.search);
-        const redirect = params.get('redirect') ?? '/admin';
+        const raw = params.get('redirect') ?? '';
+        // Restrict to same-origin paths: must start with '/' but not '//'
+        // to prevent open-redirect attacks via crafted redirect params.
+        const redirect = raw.startsWith('/') && !raw.startsWith('//') ? raw : '/admin';
         window.location.href = redirect;
       } else {
         showStatus('Invalid password. Please try again.', 'error');


### PR DESCRIPTION
## Summary
- [x] Describe the change clearly.

Adds a complete admin authentication system with login page and protected admin dashboard:

**New Pages:**
- `/login` - Password-based sign-in page with form validation and error handling
- `/admin` - Protected dashboard displaying blog post statistics and list

**New API Routes:**
- `POST /api/login` - Authenticates user with password, issues JWT token via HttpOnly cookie
- `POST /api/logout` - Clears authentication cookie

**New Middleware:**
- `_middleware.ts` - Protects `/admin` routes by verifying JWT tokens, redirects unauthenticated requests to login with redirect parameter

**Authentication Flow:**
- JWT-based session tokens (24-hour expiration)
- HttpOnly, Secure, SameSite cookies prevent XSS/CSRF attacks
- Middleware validates tokens before allowing access to admin routes
- Login page supports redirect parameter for post-auth navigation

**Admin Dashboard Features:**
- Displays total post count
- Lists all blog posts sorted by publication date (newest first)
- Sign out button with loading state
- Responsive design with glassmorphism styling

## Scripts & Docs Sync (required)
- [x] No `package.json` scripts changed

## Deployment wording guardrail (required)
- [x] Uses Cloudflare Pages Functions (`functions/` directory) for API routes and middleware
- [x] Leverages Cloudflare's native JWT verification capabilities via Web Crypto API

## Validation
- [x] No breaking changes to existing functionality
- [x] Authentication system uses standard JWT implementation with HMAC-SHA256
- [x] All routes properly handle missing/invalid credentials

## Operational impact
- [x] Requires `ADMIN_PASSWORD` and `JWT_SECRET` environment variables in Cloudflare Pages
- [x] Rollback: Remove `functions/` directory and `/login`, `/admin` pages to disable authentication
- [x] No database or external service dependencies

https://claude.ai/code/session_01FM9y2aaiYitkiJGKmNKeXz