### PR TITLE
fix(ci): add legacy-peer-deps to unblock CF Pages npm 10 build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary

- CF Pages uses npm 10 which strictly enforces peer dependencies
- `tsconfck` (bundled inside Astro) declares `peerDependencies: { typescript: "^5.0.0" }`, which excludes `typescript@6.0.2`
- npm 10 tries to auto-install `typescript@5.9.3` as the satisfying peer dep, but it's absent from the lock file
- This causes all CF Pages builds to fail with `npm ci` error: `Missing: typescript@5.9.3 from lock file`
- `legacy-peer-deps=true` in `.npmrc` instructs npm to skip strict peer dep installation (same behaviour as npm 11 locally where builds pass)

## Test plan

- [ ] CF Pages build passes after merging this PR
- [ ] `mazzeleczzare.com` deploys successfully to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)