### PR TITLE
feat: share button on hover/selection only; fix hero image mismatches

### DIFF
--- a/src/components/PostQuoteShare.tsx
+++ b/src/components/PostQuoteShare.tsx
@@ -12,6 +12,7 @@ type FeedbackLabel = 'Link copied' | 'Shared';
 const BUTTON_CLASS = 'quote-share-button';
 const PARAGRAPH_CLASS = 'quote-share-paragraph';
 const HIGHLIGHT_CLASS = 'quote-share-highlight';
+const ACTIVE_CLASS = 'quote-share-active';
 const SUCCESS_TIMEOUT_MS = 2500;
 const HIGHLIGHT_TIMEOUT_MS = 4000;
 const SHARE_SOURCE = 'quote-share';
@@ -236,6 +237,27 @@ export default function PostQuoteShare({ title, path }: PostQuoteShareProps) {
         paragraph.classList.remove(PARAGRAPH_CLASS, HIGHLIGHT_CLASS);
         cleanupQuoteIdentifier();
       });
+    });
+
+    const onSelectionChange = () => {
+      const selection = window.getSelection();
+      paragraphs.forEach((p) => p.classList.remove(ACTIVE_CLASS));
+
+      if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+        return;
+      }
+
+      const anchor = selection.getRangeAt(0).commonAncestorContainer;
+      const matched = paragraphs.find((p) => p.contains(anchor));
+      if (matched) {
+        matched.classList.add(ACTIVE_CLASS);
+      }
+    };
+
+    document.addEventListener('selectionchange', onSelectionChange);
+    cleanupHandlers.push(() => {
+      document.removeEventListener('selectionchange', onSelectionChange);
+      paragraphs.forEach((p) => p.classList.remove(ACTIVE_CLASS));
     });
 
     const searchParams = new URLSearchParams(window.location.search);

--- a/src/content/blog/concept-is-not-the-state.mdx
+++ b/src/content/blog/concept-is-not-the-state.mdx
@@ -6,7 +6,6 @@ pubDate: 2026-04-12
 author: "Mazze LeCzzare"
 category: "Essay"
 tags: ["affective science", "AI", "interpretability", "constructionism", "alignment"]
-heroImage: "/hero-lock-icon.jpg"
 heroImageOG: "/mazze-leczzare-social-preview.png"
 heroImageAlt: "A dark editorial image split between a composed surface and a hidden dimensional affect space, separated by a teal crack labeled REPRESENTATION"
 readingTime: "~14 min"

--- a/src/content/blog/we-all-float-on.mdx
+++ b/src/content/blog/we-all-float-on.mdx
@@ -10,6 +10,7 @@ tags:
   - artificial-intelligence
   - reflection
   - human-ai
+heroImage: "/triptych/triptych-mind.png"
 heroImageAlt: "A triptych: a glowing neural brain, a systems notebook with consent logic diagrams, and a compass needle pointing somewhere uncertain."
 ---
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -248,7 +248,8 @@ const articleSchema = {
       background: rgba(58, 184, 160, 0.06);
     }
 
-    .prose :global(.quote-share-paragraph:hover .quote-share-button) {
+    .prose :global(.quote-share-paragraph:hover .quote-share-button),
+    .prose :global(.quote-share-paragraph.quote-share-active .quote-share-button) {
       display: inline-block;
     }
 
@@ -262,9 +263,14 @@ const articleSchema = {
     @media (max-width: 720px) {
       .prose :global(.quote-share-button) {
         position: static;
-        display: block;
+        display: none;
         margin-top: 0.5em;
         width: max-content;
+      }
+
+      .prose :global(.quote-share-paragraph:hover .quote-share-button),
+      .prose :global(.quote-share-paragraph.quote-share-active .quote-share-button) {
+        display: block;
       }
     }
   </style>


### PR DESCRIPTION
## Summary

- **Share button**: was always visible on mobile; now hidden everywhere by default and shown only on paragraph hover (desktop) or text selection (all devices). Added `selectionchange` listener in `PostQuoteShare.tsx` that adds a `quote-share-active` class to the paragraph whose text is being highlighted.
- **Hero image fix**: `concept-is-not-the-state` was incorrectly using `/hero-lock-icon.jpg` (the cybersecurity essay's image) — removed it. `we-all-float-on` had a `heroImageAlt` about a triptych but no `heroImage` — wired it up to `/triptych/triptych-mind.png`.

## Test plan

- [ ] On desktop: share button hidden at rest, appears on paragraph hover, disappears when mouse leaves
- [ ] On desktop: select text in a paragraph → share button appears; deselect → disappears
- [ ] On mobile: share button not visible until text is long-pressed/selected
- [ ] `/blog/concept-is-not-the-state/` — no hero image (no mismatched lock icon)
- [ ] `/blog/we-all-float-on/` — triptych-mind.png renders as hero
- [ ] `/blog/the-lock-icon-is-not-security/` — lock icon hero still present (unchanged)
- [ ] `npm run check` passes

https://claude.ai/code/session_01UMBeGAMLdsiZmaaWUDu7bX