### PR TITLE
Add agent-readiness: Link headers, Markdown for Agents, API catalog, OAuth discovery, WebMCP

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -2,6 +2,26 @@ interface Env {
   JWT_SECRET: string;
 }
 
+// Cloudflare Workers runtime globals (not in standard TS lib)
+interface HTMLRewriterElement {
+  tagName: string;
+  getAttribute(name: string): string | null;
+  onEndTag(handler: () => void): void;
+  remove(): void;
+}
+interface HTMLRewriterText {
+  text: string;
+  lastInTextNode: boolean;
+}
+interface HTMLRewriterHandler {
+  element?(el: HTMLRewriterElement): void;
+  text?(chunk: HTMLRewriterText): void;
+}
+declare class HTMLRewriter {
+  on(selector: string, handler: HTMLRewriterHandler): HTMLRewriter;
+  transform(response: Response): Response;
+}
+
 async function verifyJWT(token: string, secret: string): Promise<boolean> {
   try {
     const parts = token.split(".");
@@ -46,6 +66,131 @@ async function verifyJWT(token: string, secret: string): Promise<boolean> {
   }
 }
 
+// ── Markdown for Agents ──────────────────────────────────────────────────────
+
+const SKIP_TAGS = new Set([
+  "script", "style", "noscript", "iframe", "svg", "canvas", "template",
+]);
+
+// These structural tags suppress output without contributing headings/text.
+const STRUCTURAL_SKIP_TAGS = new Set(["nav", "header", "footer", "aside"]);
+
+async function htmlToMarkdown(html: string): Promise<string> {
+  const parts: string[] = [];
+  let skipDepth = 0;
+  const linkHrefs: string[] = [];
+
+  const handler: HTMLRewriterHandler = {
+    element(el) {
+      const tag = el.tagName.toLowerCase();
+
+      if (SKIP_TAGS.has(tag) || STRUCTURAL_SKIP_TAGS.has(tag)) {
+        skipDepth++;
+        el.onEndTag(() => {
+          skipDepth = Math.max(0, skipDepth - 1);
+        });
+        return;
+      }
+
+      if (skipDepth > 0) return;
+
+      switch (tag) {
+        case "title":
+          parts.push("\n# ");
+          el.onEndTag(() => parts.push("\n\n"));
+          break;
+        case "h1":
+          parts.push("\n# ");
+          el.onEndTag(() => parts.push("\n"));
+          break;
+        case "h2":
+          parts.push("\n## ");
+          el.onEndTag(() => parts.push("\n"));
+          break;
+        case "h3":
+          parts.push("\n### ");
+          el.onEndTag(() => parts.push("\n"));
+          break;
+        case "h4":
+          parts.push("\n#### ");
+          el.onEndTag(() => parts.push("\n"));
+          break;
+        case "h5":
+          parts.push("\n##### ");
+          el.onEndTag(() => parts.push("\n"));
+          break;
+        case "h6":
+          parts.push("\n###### ");
+          el.onEndTag(() => parts.push("\n"));
+          break;
+        case "p":
+          parts.push("\n\n");
+          break;
+        case "br":
+          parts.push("\n");
+          break;
+        case "hr":
+          parts.push("\n\n---\n\n");
+          break;
+        case "li":
+          parts.push("\n- ");
+          break;
+        case "blockquote":
+          parts.push("\n> ");
+          el.onEndTag(() => parts.push("\n"));
+          break;
+        case "strong":
+        case "b":
+          parts.push("**");
+          el.onEndTag(() => parts.push("**"));
+          break;
+        case "em":
+        case "i":
+          parts.push("_");
+          el.onEndTag(() => parts.push("_"));
+          break;
+        case "code":
+          parts.push("`");
+          el.onEndTag(() => parts.push("`"));
+          break;
+        case "pre":
+          parts.push("\n```\n");
+          el.onEndTag(() => parts.push("\n```\n"));
+          break;
+        case "a": {
+          const href = el.getAttribute("href") ?? "";
+          if (href && !href.startsWith("#") && !href.startsWith("javascript:")) {
+            linkHrefs.push(href);
+            el.onEndTag(() => {
+              const h = linkHrefs.pop();
+              if (h) parts.push(` (${h})`);
+            });
+          }
+          break;
+        }
+      }
+    },
+    text(chunk) {
+      if (skipDepth > 0) return;
+      parts.push(chunk.text);
+    },
+  };
+
+  const rewriter = new HTMLRewriter().on("*", handler);
+  const transformed = rewriter.transform(
+    new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } })
+  );
+  await transformed.text();
+
+  return parts
+    .join("")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+// ── Main middleware ──────────────────────────────────────────────────────────
+
 export async function onRequest(context: {
   request: Request;
   next(): Promise<Response>;
@@ -54,19 +199,46 @@ export async function onRequest(context: {
   const { request, next, env } = context;
   const url = new URL(request.url);
 
-  // Only protect /admin routes
-  if (!url.pathname.startsWith("/admin")) {
+  // Protect /admin routes
+  if (url.pathname.startsWith("/admin")) {
+    const cookie = request.headers.get("Cookie") ?? "";
+    const tokenMatch = cookie.match(/auth_token=([^;]+)/);
+    const token = tokenMatch?.[1];
+
+    if (!token || !(await verifyJWT(token, env.JWT_SECRET))) {
+      const loginUrl = new URL("/login", request.url);
+      loginUrl.searchParams.set("redirect", url.pathname);
+      return Response.redirect(loginUrl.toString(), 302);
+    }
+
     return next();
   }
 
-  const cookie = request.headers.get("Cookie") ?? "";
-  const tokenMatch = cookie.match(/auth_token=([^;]+)/);
-  const token = tokenMatch?.[1];
+  // Markdown for Agents: serve text/markdown when the client prefers it
+  const accept = request.headers.get("Accept") ?? "";
+  if (accept.includes("text/markdown")) {
+    const response = await next();
+    const contentType = response.headers.get("Content-Type") ?? "";
 
-  if (!token || !(await verifyJWT(token, env.JWT_SECRET))) {
-    const loginUrl = new URL("/login", request.url);
-    loginUrl.searchParams.set("redirect", url.pathname);
-    return Response.redirect(loginUrl.toString(), 302);
+    if (contentType.includes("text/html")) {
+      const html = await response.text();
+      const markdown = await htmlToMarkdown(html);
+      const tokenCount = Math.ceil(markdown.length / 4);
+
+      return new Response(markdown, {
+        status: response.status,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Vary": "Accept",
+          "x-markdown-tokens": String(tokenCount),
+        },
+      });
+    }
+
+    // Non-HTML: pass through but annotate Vary so caches handle it correctly
+    const headers = new Headers(response.headers);
+    headers.set("Vary", "Accept");
+    return new Response(response.body, { status: response.status, headers });
   }
 
   return next();

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -159,7 +159,8 @@ async function htmlToMarkdown(html: string): Promise<string> {
           break;
         case "a": {
           const href = el.getAttribute("href") ?? "";
-          if (href && !href.startsWith("#") && !href.startsWith("javascript:")) {
+          const isSafe = href.startsWith("https://") || href.startsWith("http://") || href.startsWith("/");
+          if (href && isSafe) {
             linkHrefs.push(href);
             el.onEndTag(() => {
               const h = linkHrefs.pop();

--- a/public/.well-known/agent-skills/contact/SKILL.md
+++ b/public/.well-known/agent-skills/contact/SKILL.md
@@ -1,0 +1,44 @@
+# Contact API
+
+Send a message to Mazze Leczzare via the contact form endpoint.
+
+## Endpoint
+
+`POST https://mazzeleczzare.com/api/contact`
+
+`Content-Type: application/json`
+
+## Request Body
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `name` | string | yes | 2–80 characters |
+| `email` | string | yes | valid email address |
+| `message` | string | yes | 20–4000 characters |
+| `startedAt` | number | yes | Unix timestamp (ms) when user began composing; must be ≥1500ms before submission |
+| `company` | string | no | Honeypot field — must be empty or omitted |
+
+## Example
+
+```json
+{
+  "name": "Ada Lovelace",
+  "email": "ada@example.com",
+  "message": "I'd love to discuss your work on neuroscience and storytelling.",
+  "startedAt": 1700000000000
+}
+```
+
+## Responses
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Message delivered successfully |
+| 400 | Validation error (check field constraints) |
+| 429 | Rate limited — try again later |
+| 500 | Server error |
+
+## Notes
+
+- Do not populate the `company` field; it is a spam honeypot and a non-empty value will cause a 400 error.
+- The `startedAt` timestamp prevents automated spam; set it to `Date.now()` before composing the message, not immediately before sending.

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "contact",
+      "type": "skill-md",
+      "description": "Send a message to Mazze Leczzare via the contact form API (POST /api/contact).",
+      "url": "https://mazzeleczzare.com/.well-known/agent-skills/contact/SKILL.md",
+      "digest": "sha256:dd0b360b5db2cbfcb94f470d54d8834821442fc12ea12f662e04da871e45eca7"
+    },
+    {
+      "name": "share-event",
+      "type": "skill-md",
+      "description": "Record a quote-share telemetry event for a blog post paragraph (POST /api/share-event).",
+      "url": "https://mazzeleczzare.com/.well-known/agent-skills/share-event/SKILL.md",
+      "digest": "sha256:30fa21aa7539826856398504d778218f6a0d4ba14559ba87786596c760f2f761"
+    }
+  ]
+}

--- a/public/.well-known/agent-skills/share-event/SKILL.md
+++ b/public/.well-known/agent-skills/share-event/SKILL.md
@@ -1,0 +1,40 @@
+# Share Event API
+
+Record a quote-share telemetry event when a reader shares a paragraph from a blog post.
+
+## Endpoint
+
+`POST https://mazzeleczzare.com/api/share-event`
+
+`Content-Type: application/json`
+
+## Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event` | string | yes | Event type — use `"share"` |
+| `path` | string | yes | URL path of the page where the share occurred (e.g. `/blog/my-post/`) |
+| `quoteId` | string | yes | Identifier of the shared paragraph (assigned by the page) |
+
+## Example
+
+```json
+{
+  "event": "share",
+  "path": "/blog/the-jingle-of-me-radio/",
+  "quoteId": "p-3"
+}
+```
+
+## Responses
+
+| Status | Meaning |
+|--------|---------|
+| 204 | Event recorded |
+| 400 | Missing or invalid fields |
+| 429 | Rate limit exceeded (20 requests per 60 s per fingerprint) |
+
+## Notes
+
+- CORS is enforced; requests must originate from `https://mazzeleczzare.com`.
+- This endpoint is intended for first-party telemetry only.

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,31 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://mazzeleczzare.com/api/contact",
+      "service-doc": [
+        {
+          "href": "https://mazzeleczzare.com/.well-known/agent-skills/contact/SKILL.md",
+          "type": "text/markdown"
+        }
+      ]
+    },
+    {
+      "anchor": "https://mazzeleczzare.com/api/share-event",
+      "service-doc": [
+        {
+          "href": "https://mazzeleczzare.com/.well-known/agent-skills/share-event/SKILL.md",
+          "type": "text/markdown"
+        }
+      ]
+    },
+    {
+      "anchor": "https://mazzeleczzare.com/api/login",
+      "service-doc": [
+        {
+          "href": "https://mazzeleczzare.com/.well-known/oauth-authorization-server",
+          "type": "application/json"
+        }
+      ]
+    }
+  ]
+}

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1",
+  "serverInfo": {
+    "name": "com.mazzeleczzare.blog",
+    "version": "1.0.0",
+    "description": "Mazze Leczzare — essays, experiments, and field notes from a former neuroscientist turned storyteller and cybersecurity explorer."
+  },
+  "transport": {
+    "type": "http",
+    "url": "https://mazzeleczzare.com/api"
+  },
+  "capabilities": {
+    "tools": [
+      {
+        "name": "contact",
+        "description": "Send a message to the author via the contact form."
+      },
+      {
+        "name": "share-event",
+        "description": "Record a quote-share event for a blog post paragraph."
+      }
+    ],
+    "resources": [
+      {
+        "uri": "https://mazzeleczzare.com/rss.xml",
+        "name": "RSS Feed",
+        "description": "Blog post feed in RSS 2.0 format.",
+        "mimeType": "application/rss+xml"
+      }
+    ]
+  },
+  "links": {
+    "api-catalog": "https://mazzeleczzare.com/.well-known/api-catalog",
+    "agent-skills": "https://mazzeleczzare.com/.well-known/agent-skills/index.json"
+  }
+}

--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -1,0 +1,10 @@
+{
+  "issuer": "https://mazzeleczzare.com",
+  "authorization_endpoint": "https://mazzeleczzare.com/login",
+  "token_endpoint": "https://mazzeleczzare.com/api/login",
+  "token_endpoint_auth_methods_supported": ["client_secret_post"],
+  "grant_types_supported": ["password"],
+  "response_types_supported": ["token"],
+  "scopes_supported": ["admin"],
+  "service_documentation": "https://mazzeleczzare.com/.well-known/agent-skills/index.json"
+}

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -1,0 +1,7 @@
+{
+  "resource": "https://mazzeleczzare.com",
+  "authorization_servers": ["https://mazzeleczzare.com"],
+  "scopes_supported": ["admin"],
+  "resource_documentation": "https://mazzeleczzare.com/.well-known/agent-skills/index.json",
+  "resource_signing_alg_values_supported": ["HS256"]
+}

--- a/public/_headers
+++ b/public/_headers
@@ -8,3 +8,29 @@
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Resource-Policy: same-origin
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; upgrade-insecure-requests
+
+/
+  Link: </.well-known/api-catalog>; rel="api-catalog"
+  Link: </rss.xml>; rel="alternate"; type="application/rss+xml"; title="Mazze Leczzare"
+  Link: </.well-known/agent-skills/index.json>; rel="service-doc"
+  Link: </.well-known/mcp/server-card.json>; rel="service-desc"
+
+/.well-known/api-catalog
+  Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"
+  Access-Control-Allow-Origin: *
+
+/.well-known/agent-skills/index.json
+  Content-Type: application/json
+  Access-Control-Allow-Origin: *
+
+/.well-known/oauth-authorization-server
+  Content-Type: application/json
+  Access-Control-Allow-Origin: *
+
+/.well-known/oauth-protected-resource
+  Content-Type: application/json
+  Access-Control-Allow-Origin: *
+
+/.well-known/mcp/server-card.json
+  Content-Type: application/json
+  Access-Control-Allow-Origin: *

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -14,3 +14,5 @@ User-agent: GPTBot
 Disallow: /
 
 Sitemap: https://mazzeleczzare.com/sitemap-index.xml
+
+Content-Signal: ai-train=no, search=yes, ai-input=no

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,6 +52,63 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
 </HomepageLayout>
 
+<script>
+// WebMCP: expose site tools to AI agents via the browser (navigator.modelContext)
+if ('modelContext' in navigator) {
+  (navigator.modelContext as { provideContext: (ctx: unknown) => void }).provideContext({
+    tools: [
+      {
+        name: 'list_posts',
+        description: 'List recent blog posts from Mazze Leczzare. Returns title, URL, publication date, and description for each post.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            limit: {
+              type: 'integer',
+              description: 'Maximum number of posts to return (1–50, default 10).',
+              minimum: 1,
+              maximum: 50,
+              default: 10,
+            },
+          },
+        },
+        execute: async (args: { limit?: number }) => {
+          const res = await fetch('/rss.xml');
+          const xml = await res.text();
+          const doc = new DOMParser().parseFromString(xml, 'text/xml');
+          return Array.from(doc.querySelectorAll('item'))
+            .slice(0, args.limit ?? 10)
+            .map((item) => ({
+              title: item.querySelector('title')?.textContent ?? '',
+              url: item.querySelector('link')?.textContent ?? '',
+              pubDate: item.querySelector('pubDate')?.textContent ?? '',
+              description: (item.querySelector('description')?.textContent ?? '')
+                .replace(/<[^>]+>/g, '')
+                .trim(),
+            }));
+        },
+      },
+      {
+        name: 'get_rss_feed',
+        description: 'Get the URL of the blog RSS feed for subscribing or bulk-reading all posts.',
+        inputSchema: { type: 'object', properties: {} },
+        execute: async () => ({ url: 'https://mazzeleczzare.com/rss.xml', type: 'application/rss+xml' }),
+      },
+      {
+        name: 'get_contact_info',
+        description: 'Get information on how to contact Mazze Leczzare, including the contact form URL and API endpoint.',
+        inputSchema: { type: 'object', properties: {} },
+        execute: async () => ({
+          contact_form: 'https://mazzeleczzare.com/contact/',
+          api_endpoint: 'https://mazzeleczzare.com/api/contact',
+          skill_doc: 'https://mazzeleczzare.com/.well-known/agent-skills/contact/SKILL.md',
+        }),
+      },
+    ],
+  });
+}
+</script>
+
 <style>
 /* ── Writing index ──────────────────────────────────────────────────── */
 .writing-index {


### PR DESCRIPTION
## Summary

Implements all nine agent-readiness features so AI agents can discover, authenticate with, and interact with this site programmatically.

- **Content Signals** (`robots.txt`): Declares `ai-train=no, search=yes, ai-input=no` via the Content Signals draft spec.
- **Link response headers** (`_headers`): RFC 8288 `Link` headers on `/` advertising `api-catalog`, RSS alternate feed, agent-skills index, and MCP server card.
- **API catalog** (`/.well-known/api-catalog`): RFC 9727 `application/linkset+json` document listing `/api/contact`, `/api/share-event`, and `/api/login` with links to their skill documents.
- **Agent Skills discovery** (`/.well-known/agent-skills/index.json`): Agent Skills Discovery v0.2.0 index with `sha256` digests pointing to `SKILL.md` files for the contact and share-event APIs.
- **MCP Server Card** (`/.well-known/mcp/server-card.json`): SEP-1649 server card describing site tools and resources.
- **OAuth AS metadata** (`/.well-known/oauth-authorization-server`): RFC 8414 authorization server metadata pointing at `/login` and `/api/login`.
- **OAuth Protected Resource** (`/.well-known/oauth-protected-resource`): RFC 9728 metadata describing the protected `/admin` resource.
- **Markdown for Agents** (`functions/_middleware.ts`): Cloudflare Pages middleware intercepts `Accept: text/markdown` requests, converts HTML responses to markdown via `HTMLRewriter`, and returns `Content-Type: text/markdown` with `x-markdown-tokens`.
- **WebMCP** (`src/pages/index.astro`): `navigator.modelContext.provideContext()` on the homepage exposes `list_posts` (parses RSS), `get_rss_feed`, and `get_contact_info` tools to in-browser AI agents.

## Test plan

- [ ] Deploy to Cloudflare Pages preview and confirm `/.well-known/api-catalog` returns `Content-Type: application/linkset+json`
- [ ] Verify `curl -H "Accept: text/markdown" https://<preview>.pages.dev/` returns `Content-Type: text/markdown`
- [ ] Confirm homepage `Link` response headers are present with `curl -I https://<preview>.pages.dev/`
- [ ] Check `robots.txt` includes `Content-Signal` line
- [ ] Validate `/.well-known/agent-skills/index.json` is valid JSON with correct sha256 digests
- [ ] Confirm `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` return JSON
- [ ] Verify existing `/admin` auth redirect still works after middleware changes
- [ ] Run `npm run check` locally — already passing

https://claude.ai/code/session_01SMrhgxMibirXiJ8e9zAq65

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMrhgxMibirXiJ8e9zAq65)_