### PR TITLE
fix: move CSP/X-Frame-Options to middleware so /artifacts/* embeds correctly

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -195,6 +195,32 @@ async function htmlToMarkdown(html: string): Promise<string> {
     .trim();
 }
 
+// ── Security headers ─────────────────────────────────────────────────────────
+
+const BASE_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "connect-src 'self'",
+  "form-action 'self'",
+  "base-uri 'self'",
+  "upgrade-insecure-requests",
+].join("; ");
+
+const DEFAULT_CSP = `${BASE_CSP}; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'`;
+const ARTIFACT_CSP = `${BASE_CSP}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'self'`;
+
+function withSecurityHeaders(response: Response, isArtifact: boolean): Response {
+  const headers = new Headers(response.headers);
+  headers.set("Content-Security-Policy", isArtifact ? ARTIFACT_CSP : DEFAULT_CSP);
+  headers.set("X-Frame-Options", isArtifact ? "SAMEORIGIN" : "DENY");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 // ── Main middleware ──────────────────────────────────────────────────────────
 
 export async function onRequest(context: {
@@ -204,8 +230,9 @@ export async function onRequest(context: {
 }): Promise<Response> {
   const { request, next, env } = context;
   const url = new URL(request.url);
+  const isArtifact = url.pathname.startsWith("/artifacts/");
 
-  // Protect /admin routes
+  // Protect /admin routes (redirect — CSP not needed on redirects)
   if (url.pathname.startsWith("/admin")) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("redirect", url.pathname);
@@ -233,7 +260,7 @@ export async function onRequest(context: {
       }
     }
 
-    return next();
+    return withSecurityHeaders(await next(), false);
   }
 
   // Markdown for Agents: serve text/markdown when the client prefers it
@@ -251,15 +278,17 @@ export async function onRequest(context: {
       headers.set("Content-Type", "text/markdown; charset=utf-8");
       headers.set("Vary", "Accept");
       headers.set("x-markdown-tokens", String(tokenCount));
+      headers.set("Content-Security-Policy", isArtifact ? ARTIFACT_CSP : DEFAULT_CSP);
+      headers.set("X-Frame-Options", isArtifact ? "SAMEORIGIN" : "DENY");
 
       return new Response(markdown, { status: response.status, headers });
     }
 
-    // Non-HTML: pass through but annotate Vary so caches handle it correctly
-    const headers = new Headers(response.headers);
-    headers.set("Vary", "Accept");
-    return new Response(response.body, { status: response.status, headers });
+    return withSecurityHeaders(
+      new Response(response.body, { status: response.status, headers: new Headers(response.headers) }),
+      isArtifact
+    );
   }
 
-  return next();
+  return withSecurityHeaders(await next(), isArtifact);
 }

--- a/public/_headers
+++ b/public/_headers
@@ -1,23 +1,17 @@
 /*
   X-Content-Type-Options: nosniff
-  X-Frame-Options: DENY
   X-XSS-Protection: 0
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Resource-Policy: same-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; upgrade-insecure-requests
 
 /
   Link: </.well-known/api-catalog>; rel="api-catalog"
   Link: </rss.xml>; rel="alternate"; type="application/rss+xml"; title="Mazze LeCzzare"
   Link: </.well-known/agent-skills/index.json>; rel="service-doc"
   Link: </.well-known/mcp/server-card.json>; rel="service-desc"
-
-/artifacts/*
-  X-Frame-Options: SAMEORIGIN
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'self'; upgrade-insecure-requests
 
 /.well-known/api-catalog
   Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"


### PR DESCRIPTION
## Problem

Cloudflare Pages `_headers` **appends** all matching rules rather than replacing them. The `/artifacts/*` block intended to override `frame-ancestors 'none'` with `frame-ancestors 'self'`, but both CSP headers were being sent together. Browsers apply the most restrictive intersection — `frame-ancestors 'none'` always won. The iframe never loaded.

## Fix

- Move `Content-Security-Policy` and `X-Frame-Options` out of `_headers` entirely
- Handle them in `functions/_middleware.ts` using `headers.set()` (replace, not append)
- Path logic: `/artifacts/*` gets `frame-ancestors 'self'` + Google Fonts allowlist; everything else gets `frame-ancestors 'none'`
- All other security headers (`HSTS`, `Permissions-Policy`, `CORP`, `COOP`, etc.) remain in `_headers` untouched

## Test plan

- [ ] Verify `mazzeleczzare.com/artifacts/tree-of-knowledge.html` renders the interactive SVG
- [ ] Verify iframe in `/blog/the-tree-we-didnt-mean-to-build/` loads and is interactive
- [ ] Verify "Open full screen ↗" link opens the artifact correctly
- [ ] Confirm artifact response has single CSP header with `frame-ancestors 'self'`
- [ ] Confirm blog post response has CSP with `frame-ancestors 'none'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3kdpNTu88yoMEKk8xvkx4

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Cloudflare Pages header-stacking bug where `_headers` was appending both the global `frame-ancestors 'none'` and the `/artifacts/*` `frame-ancestors 'self'` rules, causing browsers to enforce the more restrictive policy and preventing artifact iframes from loading. The fix moves `Content-Security-Policy` and `X-Frame-Options` entirely into `functions/_middleware.ts`, where `headers.set()` replaces rather than appends, and path-based logic applies the correct policy per route.

- **`functions/_middleware.ts`**: Adds `withSecurityHeaders()` helper with `DEFAULT_CSP` (frame-ancestors 'none') and `ARTIFACT_CSP` (frame-ancestors 'self', Google Fonts allowlist); applied to all response paths including admin, markdown pass-through, and the default fallback.
- **`public/_headers`**: Removes `Content-Security-Policy` and `X-Frame-Options` from the global `/*` rule and drops the entire `/artifacts/*` block; all other security headers (HSTS, COOP, CORP, Permissions-Policy, etc.) are unchanged.
</details>

<h3>Confidence Score: 3/5</h3>

The core fix is correct and cleanly solves the header-stacking problem, but the non-HTML markdown pass-through branch silently lost the Vary: Accept header that was explicitly placed there for correct CDN cache behavior.

The root cause is well understood and the middleware-based fix is the right approach. The withSecurityHeaders() helper is clean, the path branching is correct, and _headers is correctly trimmed. The one regression is the dropped Vary: Accept in the non-HTML markdown pass-through — the original code had an explicit comment explaining why it was there, and the refactor removed it without replacement. This affects CDN cache keying for non-HTML responses served under the Accept: text/markdown negotiation path.

functions/_middleware.ts — specifically the non-HTML branch of the accept.includes('text/markdown') block around line 287.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| functions/_middleware.ts | Adds `withSecurityHeaders()` helper and applies CSP/X-Frame-Options via middleware for all routes; correctly differentiates `/artifacts/*` vs everything else — but drops the intentional `Vary: Accept` header from the non-HTML markdown pass-through branch. |
| public/_headers | Removes `Content-Security-Policy` and `X-Frame-Options` from the global `/*` rule and the entire `/artifacts/*` block; all other security headers are preserved. Change is clean and consistent with the middleware taking ownership of those headers. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant CF as Cloudflare Pages
    participant MW as _middleware.ts
    participant Asset as Static Asset / Function

    Browser->>CF: GET /artifacts/tree-of-knowledge.html
    CF->>MW: onRequest(context)
    Note over MW: isArtifact = true
    MW->>Asset: next()
    Asset-->>MW: Response (raw)
    MW->>MW: withSecurityHeaders(response, true)
    Note over MW: CSP: frame-ancestors 'self'<br/>X-Frame-Options: SAMEORIGIN
    MW-->>CF: Response + security headers
    CF-->>Browser: 200 OK (ARTIFACT_CSP applied)

    Browser->>CF: GET /blog/some-post/
    CF->>MW: onRequest(context)
    Note over MW: isArtifact = false
    MW->>Asset: next()
    Asset-->>MW: Response (raw)
    MW->>MW: withSecurityHeaders(response, false)
    Note over MW: CSP: frame-ancestors 'none'<br/>X-Frame-Options: DENY
    MW-->>CF: Response + security headers
    CF-->>Browser: 200 OK (DEFAULT_CSP applied)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant CF as Cloudflare Pages
    participant MW as _middleware.ts
    participant Asset as Static Asset / Function

    Browser->>CF: GET /artifacts/tree-of-knowledge.html
    CF->>MW: onRequest(context)
    Note over MW: isArtifact = true
    MW->>Asset: next()
    Asset-->>MW: Response (raw)
    MW->>MW: withSecurityHeaders(response, true)
    Note over MW: CSP: frame-ancestors 'self'<br/>X-Frame-Options: SAMEORIGIN
    MW-->>CF: Response + security headers
    CF-->>Browser: 200 OK (ARTIFACT_CSP applied)

    Browser->>CF: GET /blog/some-post/
    CF->>MW: onRequest(context)
    Note over MW: isArtifact = false
    MW->>Asset: next()
    Asset-->>MW: Response (raw)
    MW->>MW: withSecurityHeaders(response, false)
    Note over MW: CSP: frame-ancestors 'none'<br/>X-Frame-Options: DENY
    MW-->>CF: Response + security headers
    CF-->>Browser: 200 OK (DEFAULT_CSP applied)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afunctions%2F_middleware.ts%3A287-290%0A**%60Vary%3A%20Accept%60%20dropped%20from%20non-HTML%20pass-through**%0A%0AThe%20pre-PR%20code%20in%20this%20branch%20explicitly%20added%20%60Vary%3A%20Accept%60%20with%20the%20comment%20%22pass%20through%20but%20annotate%20Vary%20so%20caches%20handle%20it%20correctly.%22%20The%20new%20code%20replaces%20it%20with%20%60withSecurityHeaders%28...%29%60%20which%20never%20sets%20%60Vary%60.%20Without%20this%20header%2C%20a%20CDN%20or%20edge%20cache%20can%20serve%20a%20response%20cached%20from%20a%20%60text%2Fmarkdown%60-requesting%20client%20to%20a%20normal%20browser%20%28or%20vice%20versa%29%20if%20the%20URL%20is%20the%20same%20%E2%80%94%20because%20the%20cache%20has%20no%20signal%20that%20the%20content%20or%20intent%20varies%20by%20%60Accept%60.%20The%20HTML%20markdown%20branch%20%28above%29%20still%20correctly%20sets%20%60Vary%3A%20Accept%60%3B%20only%20the%20non-HTML%20branch%20is%20affected.%0A%0A&repo=mazze93%2Fmazze-leczzare-blog&pr=142&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=5"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=5"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=5"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
functions/_middleware.ts:287-290
**`Vary: Accept` dropped from non-HTML pass-through**

The pre-PR code in this branch explicitly added `Vary: Accept` with the comment "pass through but annotate Vary so caches handle it correctly." The new code replaces it with `withSecurityHeaders(...)` which never sets `Vary`. Without this header, a CDN or edge cache can serve a response cached from a `text/markdown`-requesting client to a normal browser (or vice versa) if the URL is the same — because the cache has no signal that the content or intent varies by `Accept`. The HTML markdown branch (above) still correctly sets `Vary: Accept`; only the non-HTML branch is affected.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["auto: \_headers \[22:11\]"](https://github.com/mazze93/mazze-leczzare-blog/commit/de6da88a0c8ae841bc09768d9b1939543829499c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41548471)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->