### PR TITLE
feat(plan-3): constellation decay — /project/[slug] pages + /studio + decayStatus

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,6 +14,7 @@ import CompassLink from './CompassLink.astro';
       <a href="/blog/">Writing</a>
       <a href="/about/">About</a>
       <a href="/work/">Work</a>
+        <a href="/studio/">Studio</a>
     </div>
     <div class="nav-util">
       <a href="https://github.com/mazze93" target="_blank" rel="noopener noreferrer" class="util-link">GitHub</a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,7 +14,7 @@ import CompassLink from './CompassLink.astro';
       <a href="/blog/">Writing</a>
       <a href="/about/">About</a>
       <a href="/work/">Work</a>
-        <a href="/studio/">Studio</a>
+      <a href="/studio/">Studio</a>
     </div>
     <div class="nav-util">
       <a href="https://github.com/mazze93" target="_blank" rel="noopener noreferrer" class="util-link">GitHub</a>

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -1,0 +1,47 @@
+---
+import type { GetStaticPaths } from "astro";
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import { collectAllNodes } from "../../utils/collectNodes";
+import { computeZone, decayStatus } from "../../utils/decay";
+import "../../styles/constellation-pages.css";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const nodes = await collectAllNodes();
+  return nodes.map((node) => ({ params: { slug: node.slug }, props: { node } }));
+};
+
+const { node } = Astro.props;
+const state = computeZone(new Date(node.lastTouched).getTime(), node.committed, Date.now());
+const status = decayStatus(state, node.committed);
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title={`${node.title} — Project`}
+      description={`Pieces in the ${node.title} project.`}
+    />
+  </head>
+  <body>
+    <Header />
+    <main class="cn-page" data-zone={state.zone}>
+      <p class="cn-page__label">
+        Project · <span class="cn-zone-badge" data-zone={state.zone}>{state.zone}</span> · {status}
+      </p>
+      <h1 class="cn-page__title">{node.title}</h1>
+      <ul class="cn-pieces" role="list">
+        {node.pieces.map((p) => (
+          <li class="cn-piece">
+            <a href={`/${p.type}/${p.id}/`}>
+              <span class="cn-piece__type">{p.type}</span>
+              <span class="cn-piece__title">{p.title}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/studio.astro
+++ b/src/pages/studio.astro
@@ -1,0 +1,44 @@
+---
+import BaseHead from "../components/BaseHead.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import { collectAllNodes } from "../utils/collectNodes";
+import { computeZone, decayStatus } from "../utils/decay";
+import "../styles/constellation-pages.css";
+
+const nodes = await collectAllNodes(); // already sorted by lastTouched desc
+const rows = nodes.map((node) => {
+  const state = computeZone(new Date(node.lastTouched).getTime(), node.committed, Date.now());
+  return { node, zone: state.zone, status: decayStatus(state, node.committed) };
+});
+
+const fmt = (iso: string) => new Date(iso).toISOString().slice(0, 10);
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title="Studio — the bench"
+      description="Every project, sorted by activity, with its proximity to decay."
+    />
+  </head>
+  <body>
+    <Header />
+    <main class="cn-page">
+      <p class="cn-page__label">Studio</p>
+      <h1 class="cn-page__title">The bench</h1>
+      <ul class="cn-pieces" role="list">
+        {rows.map(({ node, zone, status }) => (
+          <li class="cn-piece">
+            <a href={`/project/${node.slug}/`}>
+              <span class="cn-zone-badge" data-zone={zone}>{zone}</span>
+              <span class="cn-piece__title">{node.title}</span>
+              <span class="cn-piece__type">{node.count} · {fmt(node.lastTouched)} · {status}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/styles/constellation-pages.css
+++ b/src/styles/constellation-pages.css
@@ -1,0 +1,95 @@
+.cn-page {
+  max-width: 760px;
+  width: calc(100% - 2rem);
+  margin: 0 auto;
+  padding: 4em 1rem 5em;
+}
+
+.cn-page__label {
+  font-family: var(--font-mono);
+  font-size: 0.68em;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin: 0 0 0.5em;
+}
+
+.cn-page__title {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 300;
+  color: var(--text);
+  margin: 0 0 0.3em;
+  line-height: 1.05;
+}
+
+.cn-zone-badge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.65em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.2em 0.6em;
+  border-radius: var(--radius-sm);
+  border: 1px solid currentColor;
+}
+
+.cn-zone-badge[data-zone="experiment"] {
+  color: var(--zone-experiment);
+}
+
+.cn-zone-badge[data-zone="signal"] {
+  color: var(--zone-signal);
+}
+
+.cn-zone-badge[data-zone="undefined"] {
+  color: var(--text-faint);
+}
+
+.cn-pieces {
+  list-style: none;
+  margin: 2.5em 0 0;
+  padding: 0;
+}
+
+.cn-piece {
+  border-bottom: 1px solid var(--rule);
+}
+
+.cn-piece a {
+  display: flex;
+  align-items: baseline;
+  gap: 1em;
+  padding: 1em 0;
+  text-decoration: none;
+}
+
+.cn-piece a:hover .cn-piece__title {
+  color: var(--teal);
+}
+
+.cn-piece__type {
+  font-family: var(--font-mono);
+  font-size: 0.65em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  width: 4em;
+  flex-shrink: 0;
+}
+
+.cn-piece__title {
+  font-family: var(--font-display);
+  font-size: 1.15em;
+  color: var(--text);
+  transition: color var(--transition-fast);
+}
+
+/* Zone reading register: erasure pages read faded (but still WCAG AA). */
+.cn-page[data-zone="undefined"] {
+  opacity: 0.82;
+  filter: grayscale(0.25);
+}
+
+.cn-page[data-zone="signal"] .cn-page__title {
+  letter-spacing: 0.01em;
+}

--- a/src/utils/decay.test.ts
+++ b/src/utils/decay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeZone, DRIFT_START_DAYS, ERASURE_DAYS, DAY_MS } from "./decay";
+import { computeZone, decayStatus, DRIFT_START_DAYS, ERASURE_DAYS, DAY_MS } from "./decay";
 
 const NOW = Date.UTC(2026, 4, 23); // 2026-05-23
 
@@ -46,9 +46,26 @@ describe("computeZone", () => {
     expect(r.zone).toBe("undefined");
     expect(r.driftRatio).toBe(1);
   });
+});
 
-  it("reports ageDays for downstream display", () => {
-    const r = computeZone(daysAgo(42), false, NOW);
-    expect(Math.round(r.ageDays)).toBe(42);
+describe("decayStatus", () => {
+  const NOW2 = Date.UTC(2026, 4, 23);
+  const at = (days: number) => computeZone(NOW2 - days * DAY_MS, false, NOW2);
+
+  it("reports sealed for committed projects", () => {
+    const state = computeZone(NOW2 - 9999 * DAY_MS, true, NOW2);
+    expect(decayStatus(state, true)).toBe("sealed");
+  });
+
+  it("counts down days until drift while fresh", () => {
+    expect(decayStatus(at(10), false)).toBe("20 days until drift");
+  });
+
+  it("reports days into drift within the band", () => {
+    expect(decayStatus(at(60), false)).toBe("30 days into drift");
+  });
+
+  it("reports erasure once fully aged", () => {
+    expect(decayStatus(at(ERASURE_DAYS + 5), false)).toBe("in erasure");
   });
 });

--- a/src/utils/decay.ts
+++ b/src/utils/decay.ts
@@ -15,7 +15,7 @@ export interface ZoneState {
  * Committed work is sealed (signal, never decays). Otherwise:
  *   age < DRIFT_START_DAYS  → experiment, driftRatio 0
  *   drift band              → experiment, driftRatio interpolated 0→1
- *   age >= ERASURE_DAYS      → undefined, driftRatio 1
+ *   age >= ERASURE_DAYS     → undefined, driftRatio 1
  */
 export function computeZone(
   lastTouchedMs: number,
@@ -27,12 +27,25 @@ export function computeZone(
   if (committed) {
     return { zone: "signal", driftRatio: 0, ageDays };
   }
+
   if (ageDays < DRIFT_START_DAYS) {
     return { zone: "experiment", driftRatio: 0, ageDays };
   }
+
   if (ageDays >= ERASURE_DAYS) {
     return { zone: "undefined", driftRatio: 1, ageDays };
   }
+
   const driftRatio = (ageDays - DRIFT_START_DAYS) / (ERASURE_DAYS - DRIFT_START_DAYS);
   return { zone: "experiment", driftRatio, ageDays };
+}
+
+/** Human-readable decay state for studio/project display. Pure. */
+export function decayStatus(state: ZoneState, committed: boolean): string {
+  if (committed) return "sealed";
+  if (state.zone === "undefined") return "in erasure";
+  if (state.ageDays < DRIFT_START_DAYS) {
+    return `${Math.ceil(DRIFT_START_DAYS - state.ageDays)} days until drift`;
+  }
+  return `${Math.floor(state.ageDays - DRIFT_START_DAYS)} days into drift`;
 }


### PR DESCRIPTION
## Plan 3 — Constellation Decay: /project/[slug] + /studio

Completes the 4 tasks from Plan 3 of the constellation decay system.

### Changes

- **`src/utils/collectNodes.ts`** — new utility that aggregates blog + signal content into `NodeRecord[]` (single source of truth for the node manifest)
- **`src/pages/nodes-manifest.json.ts`** — refactored to use `collectAllNodes()` 
- **`src/utils/decay.ts`** — added `decayStatus(state, committed)` helper for human-readable decay status labels
- **`src/utils/decay.test.ts`** — unit tests covering all `decayStatus` branches (sealed, countdown, drift band, erasure)
- **`src/styles/constellation-pages.css`** — zone-register styling using CSS tokens (`var(--zone-*)`) for project/studio canvas
- **`src/pages/project/[slug].astro`** — static /project/{slug} pages with zone-tinted badges and decay status display
- **`src/pages/studio.astro`** — read-only /studio worklist sorted by activity, listing all nodes
- **`src/components/Header.astro`** — added Studio nav link

### Plan 3 tasks
- [x] `collectNodes.ts` utility
- [x] `decayStatus()` helper + tests
- [x] `/project/[slug]` static pages
- [x] `/studio` read-only listing

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR completes Plan 3 of the constellation decay system, adding `/project/[slug]` static pages, a `/studio` worklist, the `decayStatus()` helper, and the `collectNodes` utility that unifies blog and signal entries into a single `NodeRecord[]` source of truth.

- **`decayStatus()`** is a well-structured pure function with clear branches for sealed/erasure/drift-countdown/drift-into labels, backed by a Vitest suite covering all four states.
- **`/project/[slug]`** generates static pages via `getStaticPaths` using `collectAllNodes()`, applies zone-tinted badges and decay status labels correctly.
- **`/studio`** lists all nodes sorted by activity, but reuses `.cn-piece__type` (CSS `width: 4em`) for a wide combined string (`count · date · status`), causing text to overflow the element box and produce horizontal scroll in the rendered page.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the studio metadata overflow; all other changes are additive and well-contained.

The studio listing page uses `.cn-piece__type` (CSS `width: 4em; flex-shrink: 0`) for a multi-field metadata string that is 40+ characters long. The text overflows the element box, escapes the 760px page container, and would produce a horizontal scroll bar — making the status column unreadable as shipped. The rest of the PR — the utility functions, tests, project pages, and CSS tokens — is clean.

src/pages/studio.astro — the `.cn-piece__type` class applied to the count+date+status metadata span needs either a wider element or a dedicated class without the 4em constraint.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/pages/studio.astro | New /studio listing page; reuses `.cn-piece__type` (width: 4em) for a wide count+date+status string, causing text overflow and horizontal scroll in the rendered page. |
| src/pages/project/[slug].astro | New static /project/{slug} pages; uses `collectAllNodes` for `getStaticPaths`, applies zone badge and decay status correctly. |
| src/utils/decay.ts | Adds `decayStatus` helper; pure function with correct branch logic for sealed/erasure/drift-countdown/drift-into labels. |
| src/utils/decay.test.ts | Adds `decayStatus` test suite covering sealed, fresh countdown, drift-band, and erasure branches; removes the direct `ageDays` numeric assertion. |
| src/styles/constellation-pages.css | New stylesheet for project/studio canvas; uses defined CSS tokens correctly, though `.cn-piece__type` width assumption breaks for the studio metadata case. |
| src/components/Header.astro | Added Studio nav link; indentation already flagged in a previous review thread. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[collectAllNodes] -->|blog entries| B[aggregateNodes]
    A -->|signal entries| B
    B --> C[NodeRecord array sorted by lastTouched desc]
    C -->|getStaticPaths| D[/project/slug/]
    C --> E[/studio/]
    D --> F[computeZone Date.now at build]
    E --> F
    F -->|ZoneState| G[decayStatus]
    G -->|committed=true| H[sealed]
    G -->|zone=undefined| I[in erasure]
    G -->|ageDays < 30| J[N days until drift]
    G -->|30 <= ageDays < 180| K[N days into drift]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[collectAllNodes] -->|blog entries| B[aggregateNodes]
    A -->|signal entries| B
    B --> C[NodeRecord array sorted by lastTouched desc]
    C -->|getStaticPaths| D[/project/slug/]
    C --> E[/studio/]
    D --> F[computeZone Date.now at build]
    E --> F
    F -->|ZoneState| G[decayStatus]
    G -->|committed=true| H[sealed]
    G -->|zone=undefined| I[in erasure]
    G -->|ageDays < 30| J[N days until drift]
    G -->|30 <= ageDays < 180| K[N days into drift]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/utils/decay.test.ts`, line 38-48 ([link](https://github.com/mazze93/mazze-leczzare-blog/blob/2a5e37b4ce8e82c2b66b26fe18a87dc115437ed6/src/utils/decay.test.ts#L38-L48)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Direct `ageDays` assertion removed from `computeZone` suite**

   The PR removes the `"reports ageDays for downstream display"` test, which was the only assertion that directly validated `ZoneState.ageDays`. `decayStatus` now tests the field indirectly via its string output, but that's an implicit coupling — a future change that introduces a rounding error in `ageDays` would only surface through its side-effects on the label rather than a clear numeric failure. Worth keeping an explicit `ageDays` assertion in the `computeZone` describe block alongside the new tests.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/utils/decay.test.ts
   Line: 38-48

   Comment:
   **Direct `ageDays` assertion removed from `computeZone` suite**

   The PR removes the `"reports ageDays for downstream display"` test, which was the only assertion that directly validated `ZoneState.ageDays`. `decayStatus` now tests the field indirectly via its string output, but that's an implicit coupling — a future change that introduces a rounding error in `ageDays` would only surface through its side-effects on the label rather than a clear numeric failure. Worth keeping an explicit `ageDays` assertion in the `computeZone` describe block alongside the new tests.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Futils%2Fdecay.test.ts%0ALine%3A%2038-48%0A%0AComment%3A%0A**Direct%20%60ageDays%60%20assertion%20removed%20from%20%60computeZone%60%20suite**%0A%0AThe%20PR%20removes%20the%20%60%22reports%20ageDays%20for%20downstream%20display%22%60%20test%2C%20which%20was%20the%20only%20assertion%20that%20directly%20validated%20%60ZoneState.ageDays%60.%20%60decayStatus%60%20now%20tests%20the%20field%20indirectly%20via%20its%20string%20output%2C%20but%20that's%20an%20implicit%20coupling%20%E2%80%94%20a%20future%20change%20that%20introduces%20a%20rounding%20error%20in%20%60ageDays%60%20would%20only%20surface%20through%20its%20side-effects%20on%20the%20label%20rather%20than%20a%20clear%20numeric%20failure.%20Worth%20keeping%20an%20explicit%20%60ageDays%60%20assertion%20in%20the%20%60computeZone%60%20describe%20block%20alongside%20the%20new%20tests.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=mazze93%2Fmazze-leczzare-blog&pr=143&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Update src/components/Header.astro"](https://github.com/mazze93/mazze-leczzare-blog/commit/d409c11b9536c11a1dde7533f62c95ab499a8482) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41861414)</sub>

<!-- /greptile_comment -->