### PR TITLE
docs: close Greptile gaps in Pages→Workers migration plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,6 @@
-# Blog — Claude Context
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 > Local: `~/Projects/blog/mazze-leczzare-blog` (alias `~/Code/blog/…`) · Repo: `mazze93/mazze-leczzare-blog` · Domain: `mazzeleczzare.com`
 
@@ -28,10 +30,21 @@ npm run dev        # Astro dev server (localhost:4321)
 npm run build      # Static build → dist/
 npm run preview    # Preview dist/ locally
 npm run check      # astro build && tsc (repo-standard validation)
+npm run test       # vitest run — unit tests for src/**/*.test.ts
+npm run test:watch # vitest watch mode
 npm run docs:check # Validate doc command references and deployment terminology
 ```
 
-**Always run `npm run check` before committing any code change.**
+Run a single test file or case with vitest directly, e.g.
+`npx vitest run src/utils/decay.test.ts` or `npx vitest run -t "some test name"`.
+
+**Always run `npm run check` before committing any code change.** Tests cover
+`src/utils/` pure logic (decay, layout, node aggregation) and the admin
+dashboard's post-filtering/sorting — run `npm run test` when touching those.
+
+A `pre-push` git hook (installed via the `prepare` script into
+`.git/hooks/pre-push`) blocks pushes if `public/` has untracked files that
+would silently be missing from the deploy.
 
 ## Site Identity (`src/consts.ts`)
 
@@ -47,6 +60,7 @@ SITE_GITHUB_URL      = "https://github.com/mazze93"
 SITE_TWITTER         = "@southerncunning"
 SITE_REPO_URL        = "https://github.com/mazze93/mazze-leczzare-blog"
 SITE_DEFAULT_OG_IMAGE = "/mazze-leczzare-social-preview.png"
+COMPASS_LABEL        = "Mazze LeCzzare — home"
 ```
 
 ## Directory Structure
@@ -58,7 +72,11 @@ src/
   content/blog/       # Markdown/MDX blog posts (Content Collection)
   content/signal/     # Signal transmissions (Content Collection)
   content/tesserae/   # Tesserae — mosaic-tile fragments (Content Collection)
-  utils/collectNodes.ts # Constellation assembly — nodes for /studio, /project, /nodes-manifest.json
+  utils/              # Constellation logic, split pure-vs-Astro for testability (see Constellation System below):
+    decay.ts          #   pure — age/committed/resolved → Zone ("undefined"|"experiment"|"signal"|"resolved")
+    layout.ts         #   pure — deterministic (seeded) node position/style from a Zone
+    nodes.ts          #   pure — aggregates raw collection entries into project nodes
+    collectNodes.ts   #   astro:content wrapper — calls getCollection + nodes.ts.aggregateNodes
   layouts/            # BlogPost.astro, HomepageLayout.astro
   pages/              # File-based routes
   styles/             # global.css, homepage.css, editorial.css
@@ -68,7 +86,7 @@ src/
   env.d.ts            # Astro env type declarations
 
 functions/
-  _middleware.ts      # Global Cloudflare middleware — JWT auth + Markdown-for-Agents
+  _middleware.ts      # Global Cloudflare middleware — JWT auth + Markdown-for-Agents + security headers
   api/
     contact.ts        # Cloudflare Pages Function — contact form delivery
     share-event.ts    # Cloudflare Pages Function — quote share telemetry
@@ -94,6 +112,9 @@ files/                # HTML prototypes and design notes (not deployed)
 | `/`               | `src/pages/index.astro`             | BreathingHero + last 6 posts list        |
 | `/blog`           | `src/pages/blog/index.astro`        | All posts, sorted newest-first           |
 | `/blog/[slug]/`   | `src/pages/blog/[...slug].astro`    | Dynamic blog post route                  |
+| `/blog/field-notes` | `src/pages/blog/field-notes.astro`| Blog filtered to `contentType: 'field-note'` (essays) |
+| `/blog/dispatches` | `src/pages/blog/dispatches.astro`  | Blog filtered to `contentType: 'dispatch'` (position pieces/critiques) |
+| `/blog/artifacts` | `src/pages/blog/artifacts.astro`    | Blog filtered to `contentType: 'artifact'` (posts shipping repos/transcripts/skills) |
 | `/contact`        | `src/pages/contact.astro`           | ContactForm island                       |
 | `/about`          | `src/pages/about.astro`             | Full custom page — hero, work cards, engagement grid, contact |
 | `/cipher-gothic`  | `src/pages/cipher-gothic.astro`     | Design system documentation page        |
@@ -107,6 +128,7 @@ files/                # HTML prototypes and design notes (not deployed)
 | `/tesserae`, `/tesserae/[slug]/` | `src/pages/tesserae/`| Mosaic tiles (tesserae collection)       |
 | `/writing`        | `src/pages/writing/index.astro`     | The catalogue — all published work by form |
 | `/studio`         | `src/pages/studio.astro`            | The bench — projects by activity + decay proximity |
+| `/constellation`  | `src/pages/constellation.astro`     | Full-bleed sky view — same node geometry as the homepage hero, plus a flattened shadow index; static, no hydration |
 | `/project/[slug]/`| `src/pages/project/[slug].astro`    | Pieces belonging to one project node     |
 | `/support`        | `src/pages/support.astro`           | Support page                             |
 | `/nodes-manifest.json` | `src/pages/nodes-manifest.json.ts` | Constellation node manifest (build-time JSON) |
@@ -128,13 +150,41 @@ Defined in `src/content.config.ts`. **Three collections** (all glob-loader,
 | `signal` | Transmissions from the field ledger — verse, fragments, dispatches | `transmissionId`, `cycle`, `classification`, `status`, `origin` (all optional strings; map to TransmissionFeed props) |
 | `tesserae` | Mosaic tiles — smallest modular fragments, neither essay nor transmission | blog-common fields only |
 
-**Constellation fields** (`project?: string`, `committed?: boolean`) exist on
-`signal` and `tesserae`: they attach a piece to a project node. The
-constellation is assembled by `src/utils/collectNodes.ts` and surfaces as:
-`/studio` (every project sorted by activity and proximity to decay),
-`/project/[slug]` (pieces per project), `/writing` (the catalogue — one entry
-per published work: essay · paper · standalone · artifact · gallery ·
-instrument), and `/nodes-manifest.json` (machine-readable node manifest).
+**Constellation fields** (`project?: string`, `committed?: boolean`,
+`resolved?: boolean`) exist on **all three** collections (`blog`, `signal`,
+`tesserae`): they attach a piece to a project node. `committed` seals a node
+into permanent signal (never decays); `resolved` is a terminal archive seal —
+a deliberate editorial act, never set via `/api/ingest`.
+
+The `blog` collection additionally carries a content-type taxonomy:
+`contentType: 'artifact' | 'dispatch' | 'field-note'` (default `'field-note'`)
+plus `repoUrl?`, `artifactNote?`, `sessionTranscript?` — these back the
+`/blog/artifacts`, `/blog/dispatches`, `/blog/field-notes` sub-listings.
+
+### Constellation system
+
+A project node aggregates every published piece (across `blog`/`signal`/
+`tesserae`) that shares a `project` slug, then places it on an erasure→signal
+axis by recency and seal state. The logic is deliberately split across
+`src/utils/` so the math is unit-testable without `astro:content`:
+
+- **`decay.ts`** (pure) — `computeZone()`: age + `committed`/`resolved` →
+  `Zone` (`"undefined" | "experiment" | "signal" | "resolved"`). Precedence is
+  `resolved` > `committed` > age; drift starts at 30 days, full erasure at 180.
+- **`layout.ts`** (pure) — `seededUnit()`/`nodePosition()`/`nodeStyle()`: a
+  slug hashes (FNV-1a) to a stable 0–1 position so the same node renders in
+  the same place across the homepage hero and `/constellation` without a
+  layout database.
+- **`nodes.ts`** (pure) — `aggregateNodes()`: groups raw collection entries
+  into `NodeRecord`s (one per project).
+- **`collectNodes.ts`** (Astro-only) — the only file that calls
+  `getCollection`; wraps the three collections and hands them to `nodes.ts`.
+
+Consumers: the homepage hero (`BreathingHero.astro` → `ConstellationNodes.tsx`,
+hydrated), `/studio`, `/project/[slug]`, `/constellation` (static, no
+hydration), and `/nodes-manifest.json` (machine-readable dump of the same
+node set). `Header.astro` and `TransmissionFeed.astro` read `computeZone`
+too, for zone-aware styling outside the hero itself.
 
 ### blog collection schema
 
@@ -157,6 +207,13 @@ instrument), and `/nodes-manifest.json` (machine-readable node manifest).
   featured?: boolean        // optional — pinned/curated flag
   slug?: string             // optional — explicit URL slug override
   draft?: boolean           // optional — true hides post from all listings
+  contentType?: 'artifact' | 'dispatch' | 'field-note' // optional — default 'field-note'; drives /blog/{artifacts,dispatches,field-notes}
+  repoUrl?: string          // optional — linked repo, for contentType: 'artifact'
+  artifactNote?: string     // optional — annotation for contentType: 'artifact'
+  sessionTranscript?: string // optional — linked transcript, for contentType: 'artifact'
+  project?: string          // optional — constellation node slug (see Constellation System)
+  committed?: boolean       // optional — seals node into permanent signal
+  resolved?: boolean        // optional — terminal archive seal
 }
 ```
 
@@ -173,11 +230,13 @@ Read source for full detail — these are the non-obvious points:
 - **`BlogPost.astro`** (layout) — mounts `<AuthorCoda>` then `<PostQuoteShare client:load>` after `.prose`. All quote-share CSS lives here as scoped `:global()` rules.
 - **`HomepageLayout.astro`** — sets `data-layout="homepage"` on body; editorial deep-navy palette via `src/styles/homepage.css`.
 - **`AuthorCoda.astro`** — author byline + headshot + condensed bio rendered at the end of every post. Headshot path defaults to `/mazze-headshot.jpg`; hides gracefully if image is missing.
+- **`constellation/AirlockStrip.astro`** — plain-language orientation strip shown before the `/constellation` sky view (for visitors arriving from a CV/talk/LinkedIn link). Zero hydration.
 
 **Interactive islands (React):**
 - **`PostQuoteShare.tsx`** — paragraph-level quote sharing. Imperative DOM; assigns `data-quote-share-id` to `.prose > p`, injects share buttons, telemetries to `/api/share-event` via `sendBeacon`.
 - **`ContactForm.tsx`** — honeypot field (`company`), timing check (`startedAt`), submits JSON to `POST /api/contact`.
 - **`ThemeToggle.tsx`** — reads/writes `localStorage['theme-preference']` and `document.documentElement.dataset.theme`.
+- **`constellation/ConstellationNodes.tsx`** — mounted `client:load` inside `BreathingHero.astro` (the homepage hero). Renders live project nodes using `decay.ts`/`layout.ts` math; the one React island that isn't a form/toggle — see Key Constraints.
 
 **MDX prose components** (`src/components/` top-level — import with relative path in MDX):
 - **`Verse.astro`** — styled poetry/verse block.
@@ -200,6 +259,9 @@ Read source for full detail — these are the non-obvious points:
 | `global.css` | CSS custom properties, base resets, shared typography |
 | `homepage.css` | Deep-navy editorial palette for the homepage (`data-layout="homepage"`) |
 | `editorial.css` | Editorial/article-specific prose styles |
+| `compass.css` | Header brand-mark micro-interaction — 5 `[data-state]` phases (idle/hover/focus/engaged/…) |
+| `constellation-pages.css` | Shared `.cn-page` chrome for `/studio` and `/project/[slug]` |
+| `haven-ink.tokens.css` | Approved light-mode palette tokens for the constellation sky — **not yet wired** into the light-mode render path (tech debt, kept for a future pass) |
 
 Tailwind CSS 4 is present as a utility layer (`tailwind.config.mjs`). Preflight is disabled —
 `global.css` owns the base reset. Tailwind tokens map CSS custom properties to Tailwind
@@ -210,7 +272,7 @@ consumers. Four font families are defined: `home-display`, `home-sans`, `blog-se
 
 ### `functions/_middleware.ts` — Global middleware
 
-Runs on every request before any function. Two responsibilities:
+Runs on every request before any function. Three responsibilities:
 
 **1. Admin auth (JWT guard)**
 - Protects all `/admin/*` routes.
@@ -222,6 +284,13 @@ Runs on every request before any function. Two responsibilities:
 - When a request includes `Accept: text/markdown`, converts HTML responses to Markdown.
 - Uses `HTMLRewriter` to strip `nav`, `header`, `footer`, `script`, `style`, etc.
 - Returns `Content-Type: text/markdown` with `Vary: Accept` and `x-markdown-tokens` header.
+
+**3. Security headers**
+- Sets `Content-Security-Policy` and `X-Frame-Options` on every response via
+  `withSecurityHeaders()` — this lives here, **not** in `public/_headers`.
+- Artifact-aware: `/artifacts/*` gets a relaxed `ARTIFACT_CSP`/`SAMEORIGIN`
+  (allows Google Fonts, frameable by same origin); everything else gets
+  `DEFAULT_CSP`/`DENY`.
 
 ### `functions/api/contact.ts`
 
@@ -348,7 +417,7 @@ Middleware serves `text/markdown` content-negotiation for any AI agent that requ
 ## Key Constraints
 
 - **Static output only** — `astro.config.mjs` sets `output: "static"`. No SSR. All dynamic behaviour goes through Cloudflare Functions.
-- **Astro islands discipline** — React is used for `ThemeToggle`, `ContactForm`, `PostQuoteShare` only. Do not add React for non-interactive rendering.
+- **Astro islands discipline** — React is used for `ThemeToggle`, `ContactForm`, `PostQuoteShare`, and `ConstellationNodes` (homepage hero) only. Do not add React for non-interactive rendering.
 - **Tailwind utility layer only** — Tailwind maps CSS vars to utility classes. `preflight: false`. Do not let Tailwind own base styles or reset behaviour; `global.css` owns that.
 - **No external analytics script** — telemetry is first-party only via `share-event.ts`.
 - **No published email address** — contact routes privately through the function.

--- a/docs/superpowers/plans/2026-07-23-pages-to-workers-migration.md
+++ b/docs/superpowers/plans/2026-07-23-pages-to-workers-migration.md
@@ -29,7 +29,7 @@ to be re-derived.
 |---|---|---|
 | Framework | Astro `output: "static"` (SSG), **no** `@astrojs/cloudflare` adapter | Add the adapter in Workers mode, or serve `dist/` via Workers Static Assets |
 | Dynamic edge | **6 Pages Functions**, file-routed under `functions/` | Rewrite as a single Worker with an explicit router — this is the bulk of the work |
-| `functions/_middleware.ts` | Runs on every request: JWT auth guard for `/admin/*` (HMAC-SHA256 vs `JWT_SECRET`, optional `JWT_REVOCATION_LIST` KV) + Markdown-for-Agents (`Accept: text/markdown` → HTMLRewriter strip) | Becomes Worker middleware / router `.use()` — fails **closed** today; preserve that |
+| `functions/_middleware.ts` | Runs on every request: JWT auth guard for `/admin/*` (HMAC-SHA256 vs `JWT_SECRET`, optional `JWT_REVOCATION_LIST` KV) + Markdown-for-Agents (`Accept: text/markdown` → HTMLRewriter strip) + security headers on every response (CSP + `X-Frame-Options`, artifact-aware: `/artifacts/*` gets a relaxed `ARTIFACT_CSP`/`SAMEORIGIN`, everything else gets `DEFAULT_CSP`/`DENY`) | Becomes Worker middleware / router `.use()` — fails **closed** today; preserve that, **including the CSP/`X-Frame-Options` injection** (`withSecurityHeaders`) — it is not optional or covered by `_headers` |
 | `functions/api/contact.ts` | Same-origin, honeypot + timing + field validation, forwards to webhook | Port as route |
 | `functions/api/login.ts` | Signs 24h HS256 JWT, sets `__Host-auth_token` cookie, constant-time password compare | Port as route |
 | `functions/api/logout.ts` | Verifies JWT, writes `revoked:{jti}` to KV, clears cookie | Port as route |
@@ -49,8 +49,12 @@ touches production DNS/routes until Phase 5.
    `dist/` served by a Worker. Preview: every static route renders.
 2. **Router skeleton + middleware.** Stand up the Worker entry + router (Hono is
    the pragmatic choice) and port `_middleware.ts` — JWT guard (fail closed on
-   `JWT_SECRET` < 32 chars) + Markdown-for-Agents. Preview: `/admin/*` redirects
-   to `/login` unauth'd; `Accept: text/markdown` returns stripped markdown.
+   `JWT_SECRET` < 32 chars) + Markdown-for-Agents + **security headers**
+   (`withSecurityHeaders`: CSP and `X-Frame-Options` on every response, with the
+   artifact-aware policy branch for `/artifacts/*`). Preview: `/admin/*` redirects
+   to `/login` unauth'd; `Accept: text/markdown` returns stripped markdown; every
+   response (including redirects that skip CSP today) carries the expected CSP +
+   `X-Frame-Options`.
 3. **Port the 5 API routes** one at a time with parity tests (see §7). Wire KV +
    secrets in `wrangler.toml`. Preview: each endpoint behaves byte-for-byte like
    Pages (esp. `ingest` — it writes to the repo; test against a throwaway path).
@@ -59,8 +63,17 @@ touches production DNS/routes until Phase 5.
    Preview: security headers + agent discovery intact.
 5. **Cutover.** Point the domain at the Worker, enable Workers Builds, retire the
    Pages project + the stray Workers service. Flip the `CLAUDE.md` contract line
-   ("Deployment platform is Cloudflare Pages — not Workers") and the ci/deploy
-   docs in the **same commit**. Watch first prod deploy.
+   ("Deployment platform is Cloudflare Pages — not Workers"), `AGENTS.md`, and
+   `README.md` to Workers terminology in the **same commit**. That commit must
+   also update `scripts/ops/verify-docs-integrity.sh`'s `forbiddenDeploymentTerms`
+   list. It scans `README.md` and `AGENTS.md` (among the 7 files in
+   `deploymentTerminologyFiles`) and currently blocks `@astrojs/cloudflare`,
+   `wrangler dev`, `wrangler deploy --dry-run`, `platformProxy.enabled`, and
+   `Cloudflare Workers using` — exactly the terms a real Workers cutover needs to
+   write into those two files. Left unchanged, the cutover commit fails its own
+   CI gate the moment it writes the terminology the gate exists to forbid.
+   Update or relax the affected regexes/suggestions to match the post-migration
+   architecture in the **same commit**. Watch first prod deploy.
 
 ## 4. Anti-patterns observed (do not repeat)
 
@@ -127,6 +140,11 @@ touches production DNS/routes until Phase 5.
   fails closed.
 - **Markdown-for-Agents**: `Accept: text/markdown` returns `text/markdown` with
   `Vary: Accept` and strips nav/header/footer/script/style.
+- **Security headers**: every response carries `Content-Security-Policy` and
+  `X-Frame-Options` — `DEFAULT_CSP`/`DENY` site-wide, `ARTIFACT_CSP`/`SAMEORIGIN`
+  under `/artifacts/*`. Diff header values byte-for-byte against the current
+  Pages deployment; this is easy to silently drop since it lives only in
+  `_middleware.ts`, not in `public/_headers`.
 - **Static + Lighthouse**: all routes 200; accessibility ≥ 0.95 on every
   discovered URL (the CI gate is `error`, site-wide, **including static
   artifacts** — see PR #152 for the token-lift pattern).

--- a/docs/superpowers/plans/2026-07-23-pages-to-workers-migration.md
+++ b/docs/superpowers/plans/2026-07-23-pages-to-workers-migration.md
@@ -29,7 +29,7 @@ to be re-derived.
 |---|---|---|
 | Framework | Astro `output: "static"` (SSG), **no** `@astrojs/cloudflare` adapter | Add the adapter in Workers mode, or serve `dist/` via Workers Static Assets |
 | Dynamic edge | **6 Pages Functions**, file-routed under `functions/` | Rewrite as a single Worker with an explicit router — this is the bulk of the work |
-| `functions/_middleware.ts` | Runs on every request: JWT auth guard for `/admin/*` (HMAC-SHA256 vs `JWT_SECRET`, optional `JWT_REVOCATION_LIST` KV) + Markdown-for-Agents (`Accept: text/markdown` → HTMLRewriter strip) + security headers on every response (CSP + `X-Frame-Options`, artifact-aware: `/artifacts/*` gets a relaxed `ARTIFACT_CSP`/`SAMEORIGIN`, everything else gets `DEFAULT_CSP`/`DENY`) | Becomes Worker middleware / router `.use()` — fails **closed** today; preserve that, **including the CSP/`X-Frame-Options` injection** (`withSecurityHeaders`) — it is not optional or covered by `_headers` |
+| `functions/_middleware.ts` | Runs on every request: JWT auth guard for `/admin/*` (HMAC-SHA256 vs `JWT_SECRET`, optional `JWT_REVOCATION_LIST` KV) + Markdown-for-Agents (`Accept: text/markdown` → HTMLRewriter strip) + security headers on substantive responses (CSP + `X-Frame-Options`, artifact-aware: `/artifacts/*` gets a relaxed `ARTIFACT_CSP`/`SAMEORIGIN`, everything else gets `DEFAULT_CSP`/`DENY`) — deliberately **not** on the bare `/admin/*` → `/login` redirect, which has no body to protect | Becomes Worker middleware / router `.use()` — fails **closed** today; preserve that, **including the CSP/`X-Frame-Options` injection** (`withSecurityHeaders`) on real responses **and** its deliberate absence on the redirect — do not add headers there just to make ports "more secure by default"; it'll break parity |
 | `functions/api/contact.ts` | Same-origin, honeypot + timing + field validation, forwards to webhook | Port as route |
 | `functions/api/login.ts` | Signs 24h HS256 JWT, sets `__Host-auth_token` cookie, constant-time password compare | Port as route |
 | `functions/api/logout.ts` | Verifies JWT, writes `revoked:{jti}` to KV, clears cookie | Port as route |
@@ -50,11 +50,15 @@ touches production DNS/routes until Phase 5.
 2. **Router skeleton + middleware.** Stand up the Worker entry + router (Hono is
    the pragmatic choice) and port `_middleware.ts` — JWT guard (fail closed on
    `JWT_SECRET` < 32 chars) + Markdown-for-Agents + **security headers**
-   (`withSecurityHeaders`: CSP and `X-Frame-Options` on every response, with the
-   artifact-aware policy branch for `/artifacts/*`). Preview: `/admin/*` redirects
-   to `/login` unauth'd; `Accept: text/markdown` returns stripped markdown; every
-   response (including redirects that skip CSP today) carries the expected CSP +
-   `X-Frame-Options`.
+   (`withSecurityHeaders`: CSP and `X-Frame-Options` on substantive responses,
+   with the artifact-aware policy branch for `/artifacts/*`). Preserve the
+   redirect exception verbatim: the unauthenticated `/admin/*` → `/login`
+   redirect (and the weak-secret / revoked-JTI redirects) stay a bare
+   `Response.redirect()` with **no** CSP/`X-Frame-Options` — that's existing,
+   intentional behavior (a redirect has no body to protect), not a gap to
+   close. Preview: `/admin/*` redirects to `/login` unauth'd with the same bare
+   headers as today; `Accept: text/markdown` returns stripped markdown; every
+   non-redirect response carries the expected CSP + `X-Frame-Options`.
 3. **Port the 5 API routes** one at a time with parity tests (see §7). Wire KV +
    secrets in `wrangler.toml`. Preview: each endpoint behaves byte-for-byte like
    Pages (esp. `ingest` — it writes to the repo; test against a throwaway path).
@@ -140,11 +144,16 @@ touches production DNS/routes until Phase 5.
   fails closed.
 - **Markdown-for-Agents**: `Accept: text/markdown` returns `text/markdown` with
   `Vary: Accept` and strips nav/header/footer/script/style.
-- **Security headers**: every response carries `Content-Security-Policy` and
-  `X-Frame-Options` — `DEFAULT_CSP`/`DENY` site-wide, `ARTIFACT_CSP`/`SAMEORIGIN`
-  under `/artifacts/*`. Diff header values byte-for-byte against the current
-  Pages deployment; this is easy to silently drop since it lives only in
-  `_middleware.ts`, not in `public/_headers`.
+- **Security headers**: every non-redirect response carries
+  `Content-Security-Policy` and `X-Frame-Options` — `DEFAULT_CSP`/`DENY`
+  site-wide, `ARTIFACT_CSP`/`SAMEORIGIN` under `/artifacts/*`. The
+  unauthenticated `/admin/*` redirect (and the weak-secret / revoked-JTI
+  redirects) must **not** gain these headers — verify the parity harness
+  diffs the redirect byte-for-byte against current Pages **including its
+  absent CSP**, so a Worker port that "fixes" this by adding headers to the
+  redirect fails parity, and a port that drops headers from real responses
+  also fails parity. This is easy to get wrong in either direction since it
+  lives only in `_middleware.ts`, not in `public/_headers`.
 - **Static + Lighthouse**: all routes 200; accessibility ≥ 0.95 on every
   discovered URL (the CI gate is `error`, site-wide, **including static
   artifacts** — see PR #152 for the token-lift pattern).


### PR DESCRIPTION
## Summary
- [x] Describe the change clearly.

Two Greptile P1 findings on the (now-merged) migration plan doc PR #153 were left unresolved because that PR merged before they were addressed. This PR fixes the plan document itself, `docs/superpowers/plans/2026-07-23-pages-to-workers-migration.md`:
- **Security headers omitted from port** — Phase 2's middleware-porting step only listed the JWT guard and Markdown-for-Agents behavior, omitting that `_middleware.ts` also injects `Content-Security-Policy` and `X-Frame-Options` on every response (artifact-aware: relaxed policy under `/artifacts/*`). Updated the §2 architecture table, the Phase 2 plan step, and the §7 verification protocol to call this out explicitly so the Worker port doesn't silently drop these headers.
- **Cutover leaves terminology gate stale** — Phase 5 said to flip `CLAUDE.md`/`AGENTS.md`/`README.md` to Workers terminology in the cutover commit, but `scripts/ops/verify-docs-integrity.sh`'s `forbiddenDeploymentTerms` list (scanning `README.md`, `AGENTS.md`, etc.) explicitly blocks `@astrojs/cloudflare`, `wrangler dev`, `Cloudflare Workers using`, and friends — the very terms that commit needs to write. Added an explicit step to update that gate in the same commit.

This is a docs-only change (no code/behavior change); no new tests apply.

## Scripts & Docs Sync (required)
- [x] No `package.json` scripts changed.

## Deployment wording guardrail (required)
- [x] Wording reflects current deployment model (Cloudflare Pages) — this PR only edits a planning doc describing a *future* migration; no deployment terminology changed in the gated files.
- [x] N/A — no agent/Copilot instruction files touched.

## Validation
- [x] `npm run docs:check`
- [x] `npm run check`

## Operational impact
- [x] No Cloudflare Pages deploy impact — planning doc only.
- [x] N/A — no rollback needed for a docs change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014kJFhKr5NjwuuHjQFs5Pvm)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Documentation updates clarify the current repository and the planned Pages-to-Workers migration.
- Expands `CLAUDE.md` with current routes, constellation architecture, testing guidance, middleware security headers, and operational constraints.
- Updates the migration plan to preserve the existing security-header behavior, including bare admin redirects.
- Requires the cutover commit to update the deployment-terminology integrity gate alongside Workers terminology.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Refreshes repository guidance to document current architecture, commands, routes, content models, middleware behavior, and constraints. |
| docs/superpowers/plans/2026-07-23-pages-to-workers-migration.md | Resolves the previous parity contradiction by consistently distinguishing substantive responses from bare admin redirects and adds the terminology-gate cutover step. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: fix parity conflict from prior sec..."](https://github.com/mazze93/mazze-leczzare-blog/commit/8eb6ce1fcad347b8c059f8a95a4f36f208196f3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46815834)</sub>

<!-- /greptile_comment -->