### PR TITLE
fix: js-yaml audit CVE and homepage/about accessibility regressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4551,9 +4551,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -110,6 +110,10 @@ footer {
   color: var(--text-dim);
   text-decoration: none;
   transition: color var(--transition-fast);
+  /* Flex items become block boxes automatically; the padding brings the tap
+     target up toward the WCAG 24x24px minimum (bare text at this size falls
+     well short of it). */
+  padding: 6px 0;
 }
 
 .footer-nav a:hover,

--- a/src/components/constellation/AirlockStrip.astro
+++ b/src/components/constellation/AirlockStrip.astro
@@ -41,7 +41,13 @@ const paths = [
     font-family: "DM Mono", ui-monospace, monospace;
     font-size: 0.78rem;
     letter-spacing: 0.04em;
-    color: var(--c-dim, #7683a0);
+    /* --home-text-faint (not --c-dim): the --c-* constellation-sky tokens
+       are only ever declared under [data-theme="light"] scoped to
+       body[data-layout="constellation"]/.cn-page, so on the homepage they're
+       always undefined and this fell back to a dark-only hardcoded color —
+       unreadable against the light-mode --home-bg. --home-text-faint is
+       already remapped for both themes. */
+    color: var(--home-text-faint, #7683a0);
     border-bottom: 1px solid rgba(125, 140, 170, 0.14);
     background: transparent;
   }
@@ -56,7 +62,7 @@ const paths = [
   .airlock__paths a {
     display: inline-flex;
     align-items: center;
-    color: var(--c-ink, #c7d2e6);
+    color: var(--home-text, #c7d2e6);
     text-decoration: none;
     padding: 0.5rem 0; /* ≥44px touch target with line box */
     transition: color 140ms ease;
@@ -67,14 +73,14 @@ const paths = [
     display: inline-block;
     width: 18px;
     height: 1px;
-    background: var(--c-emerge, #7fd4d0);
+    background: var(--teal);
     margin-right: 10px;
     opacity: 0.55;
     transition: width 200ms ease, opacity 200ms ease;
   }
   .airlock__paths a:hover,
   .airlock__paths a:focus-visible {
-    color: var(--c-emerge, #7fd4d0);
+    color: var(--teal);
     outline: none;
   }
   .airlock__paths a:hover::before,

--- a/src/layouts/HomepageLayout.astro
+++ b/src/layouts/HomepageLayout.astro
@@ -29,7 +29,21 @@ const { title, description, image, minimalHeader = false } = Astro.props;
   </head>
   <body data-layout="homepage">
     <Header minimal={minimalHeader} />
-    <slot />
+    <main class="homepage-main">
+      <slot />
+    </main>
     <Footer />
   </body>
 </html>
+
+<style>
+/* Opt out of global.css's `main { width: 720px; ... }` prose constraint —
+   BreathingHero and the writing index each manage their own full-bleed
+   width, so the landmark itself must stay unconstrained. */
+.homepage-main {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -579,6 +579,13 @@ const securityEmail = SITE_EMAIL.replace('mailto:', '');
     margin: 0;
   }
 
+  /* Underlined so inline links don't rely on color alone to read as links. */
+  .about-section__hint a {
+    text-decoration: underline;
+    text-decoration-color: rgba(var(--accent-rgb), 0.5);
+    text-underline-offset: 2px;
+  }
+
   /* ── Grid ── */
   .about-grid {
     display: grid;
@@ -685,6 +692,13 @@ const securityEmail = SITE_EMAIL.replace('mailto:', '');
   }
 
   .ab-background-list p { margin: 0 0 8px; }
+
+  /* Underlined so inline links don't rely on color alone to read as links. */
+  .ab-background-list a {
+    text-decoration: underline;
+    text-decoration-color: rgba(var(--accent-rgb), 0.5);
+    text-underline-offset: 2px;
+  }
   .ab-background-list em { color: var(--text); font-style: italic; }
 
   /* ── CTA panel ── */
@@ -802,22 +816,23 @@ const securityEmail = SITE_EMAIL.replace('mailto:', '');
     font-style: italic;
   }
 
-  /* ── About footer note ── */
+  /* ── About footer note ──
+     No opacity dampening: at 0.85 the text dropped below WCAG AA's 4.5:1
+     contrast floor against --bg (~4.3:1 measured) — text-faint alone clears it. */
   .about-footer-note {
     font-family: var(--font-mono);
     font-size: 0.72rem;
     color: var(--text-faint);
     text-align: center;
     padding: 16px 0 8px;
-    opacity: 0.85;
   }
 
+  /* Underlined so the link doesn't rely on color alone to read as a link. */
   .about-footer-note a {
     color: var(--teal);
-    text-decoration: none;
+    text-decoration: underline;
+    text-underline-offset: 2px;
   }
-
-  .about-footer-note a:hover { text-decoration: underline; }
 
   .about-footer-note a:focus-visible {
     outline: 2px solid var(--teal);


### PR DESCRIPTION
## Summary
- [x] Bumps `js-yaml` 4.3.0 → 4.3.1 (transitive dep via `astro`/`@astrojs/mdx`), resolving the high-severity [CVE-2026-59870](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) that was failing `npm audit --audit-level=high` on every open PR (#158, #159). `npm audit` now reports 0 vulnerabilities. Lockfile diff is scoped to just this one dependency entry.
- [x] Fixes the real accessibility bugs behind the `/about/` Lighthouse CI failure on those same PRs — and it turns out these affect real visitors with a light-mode preference (Chrome's default when no theme is stored, which is also what Lighthouse's headless Chrome tests against), not just CI:
  - `AirlockStrip.astro` used `--c-*` "constellation sky" tokens that are only ever declared for `/constellation` in light mode; on the homepage they were always undefined, so its dark-only hardcoded fallback colors rendered at 1.33:1 / 3.34:1 contrast against the light-mode background. Switched to the already theme-aware `--home-text` / `--home-text-faint` / `--teal` tokens.
  - `about.astro`'s footer note had `opacity: 0.85` layered on `--text-faint`, dropping effective contrast to ~4.34:1 — just under WCAG AA's 4.5:1 floor. Removed the opacity.
  - Inline links in `about.astro`'s prose relied on color alone to read as links (`link-in-text-block`). Added underlines.
  - Footer nav/social links were bare text with no padding, under the 24×24px touch-target minimum. Added vertical padding.
  - The homepage had no `<main>` landmark. Added one in `HomepageLayout.astro`, scoped to opt out of `global.css`'s prose-width `main` rule so `BreathingHero` and the writing index keep their full-bleed layout.

Verified by running Lighthouse directly against the built `dist/` for both `/` and `/about/` — both now score **1.0** on accessibility (up from 0.87–0.90) — plus a Playwright screenshot pass confirming no visual regression on either page.

## Scripts & Docs Sync (required)
- [ ] N/A — no `package.json` script changes.

## Deployment wording guardrail (required)
- [x] No deployment model changes (Cloudflare Pages, unchanged).
- [x] No agent/Copilot instruction changes.

## Validation
- [x] `npm run docs:check`
- [x] `npm run check`
- [x] `npm run test` (194/194 passing)
- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] Lighthouse (direct run against `dist/`) on `/` and `/about/` → 1.0 accessibility, both up from previous failing scores
- [x] Playwright screenshots of both pages confirming no visual regression

## Operational impact
- [x] No Cloudflare Pages deploy risk — CSS/markup only, plus a patch-level dependency bump.
- [x] Rollback: revert the commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_017JHTTJzoravQwrW3GbpVJD)_