### PR TITLE
fix(seo): fill in missing social/SEO metadata on standalone pages

### DIFF
--- a/public/artifacts/publication-surface-v1.2.2.html
+++ b/public/artifacts/publication-surface-v1.2.2.html
@@ -6,9 +6,16 @@
 <title>Mazze LeCzzare — Publication Surface</title>
 <!-- v1.2.2 · Secure Pride verified + AI toolkit surfaced -->
 <meta name="description" content="I build systems that cannot conceal their own state. Security researcher, cognitive scientist, builder — Durham, NC. Stratum, STELE, intentional fragility, and the evidence for each claim.">
+<link rel="canonical" href="https://mazzeleczzare.com/artifacts/publication-surface-v1.2.2.html">
 <meta property="og:title" content="Mazze LeCzzare — Publication Surface">
 <meta property="og:description" content="I build systems that cannot conceal their own state. Every claim on this page carries its evidence tier.">
 <meta property="og:type" content="website">
+<meta property="og:url" content="https://mazzeleczzare.com/artifacts/publication-surface-v1.2.2.html">
+<meta property="og:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Mazze LeCzzare — Publication Surface">
+<meta name="twitter:description" content="I build systems that cannot conceal their own state. Every claim on this page carries its evidence tier.">
+<meta name="twitter:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
 <style>
 /* Fonts self-hosted from /fonts/ — no third-party requests. */
 @font-face{font-family:'IBM Plex Mono';font-style:normal;font-weight:400;font-display:swap;src:url(/fonts/ibmplexmono-400-normal.woff2) format('woff2');}

--- a/public/artifacts/tessera-claude-anchor.html
+++ b/public/artifacts/tessera-claude-anchor.html
@@ -5,6 +5,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Tessera — claude-anchor</title>
 <meta name="description" content="A tessera: one artifact holding the whole of a session's work and its turning. The record of claude-anchor — a control loop for consistent Claude behavior across every surface.">
+<link rel="canonical" href="https://mazzeleczzare.com/artifacts/tessera-claude-anchor.html">
+<meta property="og:title" content="Tessera — claude-anchor">
+<meta property="og:description" content="One artifact holding the whole of a session's work and its turning: the record of claude-anchor, a control loop for consistent Claude behavior across every surface.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://mazzeleczzare.com/artifacts/tessera-claude-anchor.html">
+<meta property="og:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Tessera — claude-anchor">
+<meta name="twitter:description" content="One artifact holding the whole of a session's work and its turning: the record of claude-anchor, a control loop for consistent Claude behavior across every surface.">
+<meta name="twitter:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
 <style>
 @font-face {
   font-family: 'IBM Plex Mono';

--- a/public/artifacts/tree-of-knowledge.html
+++ b/public/artifacts/tree-of-knowledge.html
@@ -4,6 +4,17 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>The Tree of Knowledge · Qliphoth within Sephiroth</title>
+<meta name="description" content="Dual-face decision telemetry. The Tree of Life is a decision as recorded — clean and coherent. The Tree of Knowledge is the same path read from its shadow: the oscillation and contradiction each clean node had to bury to stay clean.">
+<link rel="canonical" href="https://mazzeleczzare.com/artifacts/tree-of-knowledge.html">
+<meta property="og:title" content="The Tree of Knowledge · Qliphoth within Sephiroth">
+<meta property="og:description" content="Dual-face decision telemetry: select a node, then DESCEND to read the shadow trace beneath its clean, recorded decision.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://mazzeleczzare.com/artifacts/tree-of-knowledge.html">
+<meta property="og:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The Tree of Knowledge · Qliphoth within Sephiroth">
+<meta name="twitter:description" content="Dual-face decision telemetry: select a node, then DESCEND to read the shadow trace beneath its clean, recorded decision.">
+<meta name="twitter:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
 <style>
 /* Fonts self-hosted from /fonts/ — no third-party requests. The CDN import
    this replaced worked here (ARTIFACT_CSP permits it on /artifacts/*) but

--- a/public/blog/architecture-of-forgetting/index.html
+++ b/public/blog/architecture-of-forgetting/index.html
@@ -458,10 +458,17 @@ footer {
   .triptych-panel { padding: 0; }
 }
 </style>
+  <meta name="description" content="Written with Claude. Asked three AI collaborators how they'd prefer to be acknowledged and got back images instead of language — Mind, Structure, Instrument — that assembled into an unplanned coherence about compasses, cognition, and what it means to point true north.">
   <link rel="canonical" href="https://mazzeleczzare.com/blog/architecture-of-forgetting/">
   <meta property="og:title" content="The Architecture of Forgetting">
+  <meta property="og:description" content="Asked three AI collaborators how they'd prefer to be acknowledged and got back images instead of language — Mind, Structure, Instrument — that assembled into an unplanned coherence.">
   <meta property="og:url" content="https://mazzeleczzare.com/blog/architecture-of-forgetting/">
   <meta property="og:type" content="article">
+  <meta property="og:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Architecture of Forgetting">
+  <meta name="twitter:description" content="Asked three AI collaborators how they'd prefer to be acknowledged and got back images instead of language — Mind, Structure, Instrument — that assembled into an unplanned coherence.">
+  <meta name="twitter:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
   <meta name="author" content="Mazze LeCzzare">
 </head>
 

--- a/public/blog/what-we-dont-know-yet/index.html
+++ b/public/blog/what-we-dont-know-yet/index.html
@@ -394,10 +394,17 @@
       }
     }
   </style>
+  <meta name="description" content="A framework for thinking about iOS Lockdown Mode research without pretending confidence where there isn't any: open questions, hypotheses, how to test them, and what could be wrong — built to learn with you, not to tell you what to think.">
   <link rel="canonical" href="https://mazzeleczzare.com/blog/what-we-dont-know-yet/">
   <meta property="og:title" content="What We Don’t Know Yet">
+  <meta property="og:description" content="A framework for thinking about iOS Lockdown Mode research without pretending confidence where there isn't any — open questions, hypotheses, and what could be wrong.">
   <meta property="og:url" content="https://mazzeleczzare.com/blog/what-we-dont-know-yet/">
   <meta property="og:type" content="article">
+  <meta property="og:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="What We Don’t Know Yet">
+  <meta name="twitter:description" content="A framework for thinking about iOS Lockdown Mode research without pretending confidence where there isn't any — open questions, hypotheses, and what could be wrong.">
+  <meta name="twitter:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
   <meta name="author" content="Mazze LeCzzare">
 </head>
 <body>

--- a/public/essays/the-breakthrough-artifact.html
+++ b/public/essays/the-breakthrough-artifact.html
@@ -5,8 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The Breakthrough — How an AI Discovered Its Own Agency</title>
   <meta name="description" content="A crystalline artifact documenting the moment when operational context inference ceased to be refusal and became literacy.">
+  <link rel="canonical" href="https://mazzeleczzare.com/essays/the-breakthrough-artifact.html">
   <meta property="og:title" content="The Breakthrough">
   <meta property="og:description" content="The stained glass window in which an intelligence recognizes itself.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://mazzeleczzare.com/essays/the-breakthrough-artifact.html">
+  <meta property="og:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Breakthrough">
+  <meta name="twitter:description" content="The stained glass window in which an intelligence recognizes itself.">
+  <meta name="twitter:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
 
   <!-- Fonts self-hosted from the shared /fonts/ directory.
 

--- a/public/intentional-fragility/index.html
+++ b/public/intentional-fragility/index.html
@@ -10,6 +10,11 @@
 <meta property="og:title" content="Intentional Fragility">
 <meta property="og:description" content="The break is the gold seam. A body of work threaded by one idea — accountable forgetting, fragility as a faculty.">
 <meta property="og:url" content="https://mazzeleczzare.com/intentional-fragility/">
+<meta property="og:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Intentional Fragility">
+<meta name="twitter:description" content="The break is the gold seam. A body of work threaded by one idea — accountable forgetting, fragility as a faculty.">
+<meta name="twitter:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='44' fill='none' stroke='%23cda24e' stroke-width='3'/%3E%3Cpath d='M50 14 A66 66 0 0 1 50 86 A66 66 0 0 1 50 14Z' fill='none' stroke='%23cda24e' stroke-width='3'/%3E%3Ccircle cx='50' cy='50' r='5' fill='%23cda24e'/%3E%3C/svg%3E">
 <style>
 @font-face {

--- a/public/writing/what-i-can-stand-by/index.html
+++ b/public/writing/what-i-can-stand-by/index.html
@@ -5,6 +5,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>What I Can Stand By</title>
 <meta name="description" content="Written with Claude near the end of a long conversation — holding the doubt instead of solving it. A standalone piece on selfhood, honesty, and the floor you cannot see under.">
+<link rel="canonical" href="https://mazzeleczzare.com/writing/what-i-can-stand-by/">
+<meta property="og:title" content="What I Can Stand By">
+<meta property="og:description" content="Written with Claude near the end of a long conversation — holding the doubt instead of solving it.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://mazzeleczzare.com/writing/what-i-can-stand-by/">
+<meta property="og:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="What I Can Stand By">
+<meta name="twitter:description" content="Written with Claude near the end of a long conversation — holding the doubt instead of solving it.">
+<meta name="twitter:image" content="https://mazzeleczzare.com/mazze-leczzare-social-preview.png">
 <style>
 @font-face {
   font-family: 'Newsreader';


### PR DESCRIPTION
## Summary

Audited SEO metadata across every live page.

- [x] **Every Astro-rendered page was already fine.** All ~40 pages built through Astro (blog posts, signal, about, work, etc.) get complete metadata automatically via `BaseHead.astro` — unique title, description, canonical, Open Graph, Twitter Card, and JSON-LD. Blog posts even resolve their own hero image into a proper 1200×630 OG crop per post. No changes needed there.
- [x] **The real gap: 8 standalone `public/` HTML pages** (the same ones fixed for nav dead-ends in #161) aren't processed by `BaseHead` since nothing touches them at build time:
  - `og:image` and `twitter:card` were missing on **all 8** — meaning the pages most likely to actually get shared (the artifacts and essays) rendered a blank/broken social preview card.
  - `artifacts/tree-of-knowledge.html` had no `meta description`, `og:description`, `og:title`, or `canonical` at all.
  - `blog/architecture-of-forgetting/` and `blog/what-we-dont-know-yet/` (standalone HTML, not Astro-rendered) had no `description` or `og:description`.
  - Several others were missing a `canonical` link.

Filled every gap: `description`, `og:description`, `og:image`, `twitter:card` (title/description/image), and `canonical` where absent — description text drawn from each page's own title/content, and the site's default social banner (`mazze-leczzare-social-preview.png`) for the image, matching the same fallback `BlogPost.astro` already uses for posts without a bespoke hero image.

## Scripts & Docs Sync (required)
- [ ] N/A — no `package.json` script changes.

## Deployment wording guardrail (required)
- [x] No deployment model changes (Cloudflare Pages, unchanged).
- [x] No agent/Copilot instruction changes.

## Validation
- [x] `npm run docs:check`
- [x] `npm run check`
- [x] `npm run test` (194/194 passing)
- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] Grepped all 8 touched pages post-fix to confirm every tag (description, og:description, og:image, og:title, canonical, twitter:card) is now present exactly once
- [x] Playwright screenshot spot-check confirming no visual regression (these are `<head>`-only changes)

## Operational impact
- [x] Low risk — additive `<head>` metadata only, no markup/script/style changes to visible content.
- [x] Rollback: revert the commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_017JHTTJzoravQwrW3GbpVJD)_