### PR TITLE
fix(deps): bump nanoid 3.3.16 -> 3.3.18 to clear the audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5966,9 +5966,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

One-line lockfile bump: `nanoid` **3.3.16 → 3.3.18**. `package.json` is untouched.

## Why

CI's `npm audit --audit-level=high` step fails on [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — *nanoid <3.3.17: custom generators can loop indefinitely when size is zero*.

The advisory was published **after** main's last green CI run (2026-08-07), so main goes red on its next push even though nothing in main changed. Confirmed by reproducing on `main@92641ae`: `npm audit --audit-level=high` exits 1.

This first surfaced as a red CI run on `claude/research-program-operations` ([run 31230704013](https://github.com/mazze93/mazze-leczzare-blog/actions/runs/31230704013)). The build itself was never broken there — 42 pages compiled cleanly; only the audit gate failed. That branch got the same bump directly so it goes green now; this PR fixes the base so every other branch inherits it.

## Approach

`nanoid` is transitive — `astro`/`@astrojs/react` → `vite` → `postcss`. 3.3.18 sits inside postcss's existing `^3.3.11` range, so `npm update nanoid --package-lock-only` resolves it with no `overrides` entry and no direct dependency added. Deliberately avoided an `overrides` pin: that would be a permanent policy statement needing later cleanup, where a patch-level lockfile bump suffices.

## Verification

Reproduced and verified in a clean clone, matching CI's install path (`npm install --prefer-offline`, not `npm ci`):

| Step | Before | After |
| --- | --- | --- |
| `npm audit --audit-level=high` | exit 1 — 1 high severity | **exit 0 — 0 vulnerabilities** |
| `npm run check` (astro build + tsc) | exit 0 | **exit 0 — 42 pages** |

Diff is 3 lines in `package-lock.json` (version, resolved, integrity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)