### PR TITLE
ci: run the test suite, pin actions to SHAs, install from the lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,31 @@ concurrency:
 
 jobs:
   build:
-    name: Build & type-check
+    name: Test, type-check & build
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      # Pinned to full commit SHAs rather than @v7. A tag is mutable and can be
+      # repointed at arbitrary code after review; a SHA cannot.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
+          cache: npm
 
-      - name: Install dependencies
-        run: |
-          echo "npm version: $(npm --version)"
-          npm install --prefer-offline
-          echo "installed via npm install"
+      # `npm ci`, not `npm install --prefer-offline`. `npm install` is free to
+      # resolve a DIFFERENT tree than package-lock.json, so CI was not testing
+      # the lockfile that review and deploy actually use. `ci` installs the
+      # lockfile exactly and fails loudly if it disagrees with package.json.
+      - name: Install (locked)
+        run: npm ci
+
+      # The 194-test vitest suite. It existed and passed but nothing ran it,
+      # so a logic regression in src/utils could reach main with CI green.
+      # Placed before the build so it fails fast on logic, not after a build.
+      - name: Test
+        run: npm test
 
       - name: Type-check + build
         run: npm run check


### PR DESCRIPTION
Three defects in one workflow, found by sweeping the fleet for *"has tests but
nothing runs them."*

### 1. The tests never ran
`src/utils` has a **194-test vitest suite across 6 files**. It passes — it was
simply never wired into CI. A logic regression in `src/utils` could reach `main`
with every check green.

The step goes **before** the build, so it fails fast on logic rather than after
a full Astro build.

### 2. Install did not use the lockfile
The step ran `npm install --prefer-offline`, which is free to resolve a
**different tree** than `package-lock.json`. CI was therefore not testing the
dependency tree that review and deploy actually use — the same class of gap that
makes an audit read clean against a tree nobody ships.

Now `npm ci`. **Verified it succeeds on this repo before switching.** The two
debug `echo` lines went with it.

### 3. Actions were on mutable tags
`actions/checkout@v7` and `actions/setup-node@v7` → full commit SHAs. A tag can
be repointed at arbitrary code after review; a SHA cannot. This is the
convention already applied across the rest of the fleet.

Also added `cache: npm`, which `npm ci` can now use.

## Deliberately unchanged
The audit step stays at `--audit-level=high`. That's a policy call, not a
defect, and this repo is currently at **0 vulnerabilities** across both
production and dev. Happy to tighten it to the fleet pattern (production gated
at zero, dev report-only) if you want — separate decision.

## Verification
Ran locally on a clean `npm ci` clone:

| step | result |
|---|---|
| `npm ci` | rc=0 |
| `npm test` | rc=0 — 6 files, **194/194 passed** |
| `npm run check` | rc=0 — 43 pages built, Complete |
| `npm audit --audit-level=high` | rc=0 — 0 vulnerabilities |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172CPa6YcAjMwj6ajYDBXx1